### PR TITLE
Grafana visualization server

### DIFF
--- a/src/grafana/Dockerfile
+++ b/src/grafana/Dockerfile
@@ -1,0 +1,28 @@
+FROM grafana/grafana:latest
+
+USER grafana
+
+ARG GF_INSTALL_PLUGINS=""
+
+##Setting up the DB
+#We paste our own DB configuration
+COPY src/grafana/datasources/datasources.yaml etc/grafana/provisioning/datasources/
+
+### Pre installing our dashboards
+#We copy our sample.yaml to tell where to search for our dashboards
+COPY src/grafana/dashboards/dashboards.yaml /etc/grafana/provisioning/dashboards/
+#We copy our dashboards in the repertory we tell to search for
+COPY src/grafana/dashboards/*.json /var/lib/grafana/dashboards/
+
+
+
+RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
+    OLDIFS=$IFS; \
+        IFS=','; \
+    for plugin in ${GF_INSTALL_PLUGINS}; do \
+        IFS=$OLDIFS; \
+        grafana-cli --pluginsDir "$GF_PATHS_PLUGINS" plugins install ${plugin}; \
+    done; \
+fi
+
+

--- a/src/grafana/dashboards/build_inspector.json
+++ b/src/grafana/dashboards/build_inspector.json
@@ -1,0 +1,263 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "A detailed list of the jobs of the inspected build. This page is not intended to be accessed directly but through the Project Inspector dashboard, in order to properly set the build identifier.",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1528977346708,
+  "links": [],
+  "panels": [
+    {
+      "columns": [],
+      "datasource": "infrabox",
+      "description": "A list of all the jobs of the inspected build.",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 22,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "$$hashKey": "object:139",
+          "alias": "Project",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "p_name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:140",
+          "alias": "Build Number",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "build_number",
+          "thresholds": [],
+          "type": "string",
+          "unit": "locale"
+        },
+        {
+          "$$hashKey": "object:141",
+          "alias": "Restarts",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "restart_counter",
+          "thresholds": [],
+          "type": "number",
+          "unit": "locale"
+        },
+        {
+          "$$hashKey": "object:142",
+          "alias": "Job name",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": true,
+          "linkTargetBlank": true,
+          "linkTooltip": "Open Job Inspector",
+          "linkUrl": "d/EivX9TIiz/job-inspector?orgId=1&var-id=${__cell_6}",
+          "mappingType": 1,
+          "pattern": "j_name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:143",
+          "alias": "Allocated memory",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": false,
+          "mappingType": 1,
+          "pattern": "memory",
+          "thresholds": [],
+          "type": "number",
+          "unit": "decmbytes"
+        },
+        {
+          "$$hashKey": "object:144",
+          "alias": "Allocated cores",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "cpu",
+          "thresholds": [],
+          "type": "string",
+          "unit": "locale"
+        },
+        {
+          "$$hashKey": "object:145",
+          "alias": "Job ID",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": true,
+          "linkTargetBlank": true,
+          "linkTooltip": "Open Job Inspector",
+          "linkUrl": "d/EivX9TIiz/job-inspector?orgId=1&var-id=${__cell}",
+          "mappingType": 1,
+          "pattern": "id",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "$$hashKey": "object:126",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "select p.name as p_name, b.build_number, b.restart_counter, j.name as j_name, j.memory, j.cpu , j.id \nfrom project p, build b, job j \nwhere p.id = j.project_id AND b.id = j.build_id AND b.id = '[[bid]]'",
+          "refId": "A"
+        }
+      ],
+      "title": "Job list",
+      "transform": "table",
+      "type": "table"
+    }
+  ],
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": "0006fa7e-b193-4dd2-a746-6c6be16f7d8c",
+          "value": "0006fa7e-b193-4dd2-a746-6c6be16f7d8c"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "bid",
+        "options": [
+          {
+            "selected": true,
+            "text": "0006fa7e-b193-4dd2-a746-6c6be16f7d8c",
+            "value": "0006fa7e-b193-4dd2-a746-6c6be16f7d8c"
+          },
+          {
+            "selected": false,
+            "text": "0009ad79-6814-44c4-b33b-66326af7e849",
+            "value": "0009ad79-6814-44c4-b33b-66326af7e849"
+          },
+          {
+            "selected": false,
+            "text": "00225b05-6417-49d6-846a-6aab6a105695",
+            "value": "00225b05-6417-49d6-846a-6aab6a105695"
+          },
+          {
+            "selected": false,
+            "text": "005d6f95-68d7-41d3-88a9-8c323eb66f4f",
+            "value": "005d6f95-68d7-41d3-88a9-8c323eb66f4f"
+          }
+        ],
+        "query": "0006fa7e-b193-4dd2-a746-6c6be16f7d8c,0009ad79-6814-44c4-b33b-66326af7e849,00225b05-6417-49d6-846a-6aab6a105695,005d6f95-68d7-41d3-88a9-8c323eb66f4f",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Build Inspector",
+  "uid": "ieOb3TSiz",
+  "version": 1
+}

--- a/src/grafana/dashboards/cluster_inspector.json
+++ b/src/grafana/dashboards/cluster_inspector.json
@@ -1,0 +1,826 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "$$hashKey": "object:3640",
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "This dashboard offers a more specific overview of each cluster.",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 3,
+  "iteration": 1529658438657,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "title": "Basic Information",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "description": "The number of nodes connected to the inspected cluster.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 6,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": " nodes",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "nodes",
+      "targets": [
+        {
+          "$$hashKey": "object:3854",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT nodes FROM cluster WHERE name = '[[cluster]]'",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Connected nodes",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "decimals": null,
+      "description": "Amount of jobs of different states over time among the inspected cluster.",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 21,
+        "x": 3,
+        "y": 1
+      },
+      "id": 23,
+      "interval": "5s",
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "$$hashKey": "object:3933",
+          "expr": "job_current_count{cluster='[[cluster]]'}",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "5s",
+          "intervalFactor": 1,
+          "legendFormat": "{{state}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:3961",
+          "decimals": 0,
+          "format": "short",
+          "label": "Jobs",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:3962",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 14,
+      "panels": [],
+      "repeat": null,
+      "title": "Ressources",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Total amount of allocated memory by running jobs among the inspected cluster.",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 0,
+        "y": 9
+      },
+      "id": 12,
+      "interval": "5s",
+      "legend": {
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 0.5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "$$hashKey": "object:4258",
+          "alias": "",
+          "expr": "sum(rsc_current_count{cluster=\"[[cluster]]\", rsc=\"mem\"}) by(rsc)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Memory allocation",
+          "rawSql": "SELECT to_timestamp(foo.time) as time, sum(mem) as mem FROM(\n\nSELECT\n  $__timeGroup(start_date,'30s'),\n  sum(memory) as mem\nFROM job\nWHERE (start_date, end_date) OVERLAPS ($__timeFrom(), $__timeTo()) AND cluster_name LIKE [[cluster]] and start_date is not null and end_date is not null\nGROUP BY time\nunion all\nSELECT\n  $__timeGroup(end_date,'30s'),\n  sum(memory) as mem\nFROM job\nWHERE (start_date, end_date) OVERLAPS ($__timeFrom(), $__timeTo()) AND cluster_name LIKE [[cluster]] and start_date is not null and end_date is not null\nGROUP BY time\n) as foo GROUP by to_timestamp(foo.time) ORDER by to_timestamp(foo.time)\n",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Memory use - Over time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:4760",
+          "format": "decmbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:4761",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "decimals": 2,
+      "description": "Ratio of current running job's allocated memory among the inspected cluster capacity.",
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": false
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 16,
+        "y": 9
+      },
+      "id": 18,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "percentage",
+      "targets": [
+        {
+          "$$hashKey": "object:4529",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT sum(j.memory)::float*100 / (SELECT memory_capacity/1024 FROM cluster WHERE name ='[[cluster]]') as percentage\nFROM job j\nWHERE j.cluster_name = '[[cluster]]' AND j.state = 'running'",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "80,90",
+      "title": "Memory use - Current",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "0 %",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "description": "Memory capacity of the inspected cluster.",
+      "format": "deckbytes",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 19,
+        "y": 9
+      },
+      "id": 20,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "memory_capacity",
+      "targets": [
+        {
+          "$$hashKey": "object:4630",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT memory_capacity\nFROM cluster\nWHERE name = '[[cluster]]'\n",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Memory capacity",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Total amount of allocated CPU cores for all running jobs of the inspected cluster.",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 0,
+        "y": 16
+      },
+      "id": 15,
+      "interval": "5s",
+      "legend": {
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "$$hashKey": "object:4474",
+          "alias": "",
+          "expr": "sum(rsc_current_count{cluster=\"[[cluster]]\", rsc=\"cpu\"}) by(rsc)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Allocated cores",
+          "rawSql": "SELECT to_timestamp(foo.time) as time, sum(cpu) as cpu FROM(\n\nSELECT\n  $__timeGroup(start_date,'30s'),\n  sum(cpu) as cpu\nFROM job\nWHERE (start_date, end_date) OVERLAPS ($__timeFrom(), $__timeTo()) AND cluster_name LIKE [[cluster]] and start_date is not null and end_date is not null\nGROUP BY time\nunion all\nSELECT\n  $__timeGroup(end_date,'30s'),\n  sum(cpu) as cpu\nFROM job\nWHERE (start_date, end_date) OVERLAPS ($__timeFrom(), $__timeTo()) AND cluster_name LIKE [[cluster]] and start_date is not null and end_date is not null\nGROUP BY time\n) as foo GROUP by to_timestamp(foo.time) ORDER by to_timestamp(foo.time)\n",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CPU use - Over time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:4879",
+          "decimals": null,
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:4880",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "decimals": 2,
+      "description": "Ratio of current running job's allocated CPU cores among the inspected cluster capacity.",
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": false
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 16,
+        "y": 16
+      },
+      "id": 17,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "percentage",
+      "targets": [
+        {
+          "$$hashKey": "object:4569",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT sum(j.cpu)::float*100 / (SELECT cpu_capacity FROM cluster WHERE name = '[[cluster]]') as percentage\nFROM job j\nWHERE j.cluster_name = '[[cluster]]' AND j.state = 'running'",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "80,90",
+      "title": "CPU use - Current",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "0 %",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "description": "CPU cores capacity of the inspected cluster.",
+      "format": "short",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 19,
+        "y": 16
+      },
+      "id": 21,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": " cores",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "cpu_capacity",
+      "targets": [
+        {
+          "$$hashKey": "object:4714",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT cpu_capacity\nFROM cluster\nWHERE name = '[[cluster]]'\n",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "CPU capacity",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "calico",
+          "value": "calico"
+        },
+        "datasource": "infrabox",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Inspected Cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [
+          {
+            "$$hashKey": "object:3892",
+            "selected": true,
+            "text": "calico",
+            "value": "calico"
+          },
+          {
+            "$$hashKey": "object:3893",
+            "selected": false,
+            "text": "master",
+            "value": "master"
+          }
+        ],
+        "query": "select distinct name from cluster",
+        "refresh": 0,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Cluster Inspector",
+  "uid": "phgvzfHmz",
+  "version": 1
+}

--- a/src/grafana/dashboards/dashboards.yaml
+++ b/src/grafana/dashboards/dashboards.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+providers:
+ - name: 'infrabox'
+   orgId: 1
+   folder: ''
+   type: file
+   disableDeletion : true
+   options:
+     path: /var/lib/grafana/dashboards

--- a/src/grafana/dashboards/global_dashboard.json
+++ b/src/grafana/dashboards/global_dashboard.json
@@ -1,0 +1,1182 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "This dashboard offers a global overview of the Infrabox structure. It should contains every important information.",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "title": "Basic Information",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "description": "The total number of projects registered in the database.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 4,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": " projects",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "count",
+      "targets": [
+        {
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT count(id)\nFROM project",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Project Count",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "description": "The total number of clusters registered in the database.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 5,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": " clusters",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "count",
+      "targets": [
+        {
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT count(name)\nFROM cluster",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Cluster Count",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "description": "The total number of cluster's nodes registered in the database.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 6,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": " nodes",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "sum",
+      "targets": [
+        {
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT SUM(nodes)\nFROM cluster",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Node Count",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "description": "The total number of users registered in the database. Does include the root user.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      },
+      "id": 7,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": " users",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "count",
+      "targets": [
+        {
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT count(id)\nfrom public.user",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "User Count",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "columns": [],
+      "datasource": "infrabox",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 10,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "$$hashKey": "object:197",
+          "alias": "Memory use",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "mem_use",
+          "thresholds": [],
+          "type": "number",
+          "unit": "percentunit"
+        },
+        {
+          "$$hashKey": "object:198",
+          "alias": "CPU use",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "cpu_use",
+          "thresholds": [],
+          "type": "number",
+          "unit": "percentunit"
+        },
+        {
+          "$$hashKey": "object:199",
+          "alias": "NAME",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": true,
+          "linkTooltip": "Inspect",
+          "linkUrl": "d/phgvzfHmz/cluster-inspector?orgId=1&var-cluster=${__cell}",
+          "mappingType": 1,
+          "pattern": "name",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:200",
+          "alias": "Connected Nodes",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "nodes",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:201",
+          "alias": "Running jobs",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "running",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:202",
+          "alias": "Scheduled jobs",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "scheduled",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:203",
+          "alias": "Queued jobs",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "queued",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "$$hashKey": "object:170",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT c.name, c.nodes, count(j.id) filter (WHERE j.state = 'running') as running,\n  count(j.id) filter (WHERE j.state = 'scheduled') as scheduled,\n  count(j.id) filter (WHERE j.state = 'queued') as queued,\n  (sum(j.cpu) FILTER (WHERE j.state = 'running' ))::float / c.cpu_capacity as cpu_use, \n  (sum(j.memory) filter (WHERE j.state = 'running'))::float / c.memory_capacity * 1024 as mem_use\nFROM cluster c LEFT OUTER JOIN job j\nON c.name = j.cluster_name\nGROUP BY c.name",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Overview",
+      "transform": "table",
+      "type": "table"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Amount of jobs of different states over time.",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 23,
+      "interval": "5s",
+      "legend": {
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "$$hashKey": "object:1147",
+          "expr": "sum(job_current_count) by(state)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{state}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "Jobs",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 14,
+      "panels": [],
+      "repeat": null,
+      "title": "Ressources",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Total amount of allocated memory by running jobs among all clusters.",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 16,
+        "x": 0,
+        "y": 14
+      },
+      "id": 12,
+      "interval": "5s",
+      "legend": {
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "$$hashKey": "object:2669",
+          "alias": "",
+          "expr": "sum(rsc_current_count{cluster=\"'%'\", rsc=\"mem\"})",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Memory allocation",
+          "rawSql": "SELECT to_timestamp(foo.time) as time, sum(mem) as mem FROM(\n\nSELECT\n  $__timeGroup(start_date,'30s'),\n  sum(memory) as mem\nFROM job\nWHERE (start_date, end_date) OVERLAPS ($__timeFrom(), $__timeTo()) AND cluster_name LIKE [[cluster]] and start_date is not null and end_date is not null\nGROUP BY time\nunion all\nSELECT\n  $__timeGroup(end_date,'30s'),\n  sum(memory) as mem\nFROM job\nWHERE (start_date, end_date) OVERLAPS ($__timeFrom(), $__timeTo()) AND cluster_name LIKE [[cluster]] and start_date is not null and end_date is not null\nGROUP BY time\n) as foo GROUP by to_timestamp(foo.time) ORDER by to_timestamp(foo.time)\n",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Memory use - Over time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:2697",
+          "format": "decmbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:2698",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "decimals": 2,
+      "description": "Ratio of current running job's allocated memory among the sum of very cluster's capacity.",
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": false
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 16,
+        "y": 14
+      },
+      "id": 18,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "percentage",
+      "targets": [
+        {
+          "$$hashKey": "object:2309",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT sum(j.memory)::float*100 / (SELECT sum(memory_capacity)/1024 FROM cluster) as percentage\nFROM job j\nWHERE j.state = 'running'",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "80,90",
+      "title": "Memory use - Current",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "0 %",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "description": "Total memory capacity of the clusters.",
+      "format": "deckbytes",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 19,
+        "y": 14
+      },
+      "id": 20,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "sum",
+      "targets": [
+        {
+          "$$hashKey": "object:2521",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT sum(memory_capacity)\nFROM cluster\n",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Memory capacity",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Total amount of allocated cores by running jobs among all clusters.",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 16,
+        "x": 0,
+        "y": 19
+      },
+      "id": 15,
+      "interval": "5s",
+      "legend": {
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "$$hashKey": "object:1372",
+          "alias": "",
+          "expr": "sum(rsc_current_count{cluster=\"'%'\", rsc=\"cpu\"})",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Allocated cores",
+          "rawSql": "SELECT to_timestamp(foo.time) as time, sum(cpu) as cpu FROM(\n\nSELECT\n  $__timeGroup(start_date,'30s'),\n  sum(cpu) as cpu\nFROM job\nWHERE (start_date, end_date) OVERLAPS ($__timeFrom(), $__timeTo()) AND cluster_name LIKE [[cluster]] and start_date is not null and end_date is not null\nGROUP BY time\nunion all\nSELECT\n  $__timeGroup(end_date,'30s'),\n  sum(cpu) as cpu\nFROM job\nWHERE (start_date, end_date) OVERLAPS ($__timeFrom(), $__timeTo()) AND cluster_name LIKE [[cluster]] and start_date is not null and end_date is not null\nGROUP BY time\n) as foo GROUP by to_timestamp(foo.time) ORDER by to_timestamp(foo.time)\n",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CPU use - Over time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:2808",
+          "decimals": null,
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:2809",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "decimals": 2,
+      "description": "Ratio of current running job's allocated CPU cores among the sum of every cluster's capacity.",
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": false
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 16,
+        "y": 19
+      },
+      "id": 17,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "percentage",
+      "targets": [
+        {
+          "$$hashKey": "object:2401",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT sum(j.cpu)::float*100 / (SELECT sum(cpu_capacity) FROM cluster ) as percentage\nFROM job j\nWHERE j.state = 'running'",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "80,90",
+      "title": "CPU use - Current",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "0 %",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "description": "Total CPU capacity of the clusters.",
+      "format": "short",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 19,
+        "y": 19
+      },
+      "id": 21,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": " cores",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "sum",
+      "targets": [
+        {
+          "$$hashKey": "object:2613",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT sum(cpu_capacity)\nFROM cluster",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "CPU capacity",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    }
+  ],
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Global Dashboard",
+  "uid": "kfLKkfHik",
+  "version": 1
+}

--- a/src/grafana/dashboards/job_inspector.json
+++ b/src/grafana/dashboards/job_inspector.json
@@ -1,0 +1,533 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "time":{
+  	"from" :"now-7d",
+	"to":"now"
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1528978361147,
+  "links": [],
+  "panels": [
+    {
+      "columns": [],
+      "datasource": "infrabox",
+      "description": "Some general informations about the inspected job. This page is not intended to be accessed directly but through the Build Inspector dashboard, in order to properly set the job identifier.",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 14,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "$$hashKey": "object:288",
+          "alias": "Project",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "p_name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:321",
+          "alias": "Build Number",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "build_number",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:344",
+          "alias": "Restarts",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "restart_counter",
+          "thresholds": [],
+          "type": "number",
+          "unit": "locale"
+        },
+        {
+          "$$hashKey": "object:357",
+          "alias": "Job Name",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "j_name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:370",
+          "alias": "Allocated cores",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "cpu",
+          "thresholds": [],
+          "type": "number",
+          "unit": "locale"
+        },
+        {
+          "$$hashKey": "object:504",
+          "alias": "Allocated memory",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "memory",
+          "thresholds": [],
+          "type": "number",
+          "unit": "decmbytes"
+        },
+        {
+          "$$hashKey": "object:517",
+          "alias": "Cluster cores capacity",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "cpu_capacity",
+          "thresholds": [],
+          "type": "number",
+          "unit": "locale"
+        },
+        {
+          "$$hashKey": "object:530",
+          "alias": "Cluster memory capacity",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "memory_capacity",
+          "thresholds": [],
+          "type": "number",
+          "unit": "deckbytes"
+        },
+        {
+          "$$hashKey": "object:670",
+          "alias": "Job ID",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "id",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "$$hashKey": "object:206",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT p.name as p_name, b.build_number, b.restart_counter, j.name as j_name, j.cpu, j.memory, c.cpu_capacity, c.memory_capacity, j.id\nFROM project p, build b, job j, cluster c\nWHERE p.id = j.project_id AND b.id = j.build_id AND c.name = j.cluster_name AND j.id = '[[id]]'",
+          "refId": "A"
+        }
+      ],
+      "title": "General Information",
+      "transform": "table",
+      "type": "table"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "infrabox",
+      "description": "Graphical representation of the used memory as registered in the database.",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 6,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "$$hashKey": "object:746",
+          "alias": "",
+          "format": "time_series",
+          "hide": false,
+          "rawSql": "SELECT\n  $__time(date),\n  mem::float as used,\n  mem_j_limit as job_limit\nFROM (\n  select to_timestamp((elm::jsonb->'date')::text::int) as date, elm::jsonb->>'mem'::text as mem, mem_j_limit from (\n    select\n      jsonb_array_elements(j.stats::jsonb->'[[id]]') as elm, j.memory as mem_j_limit\n    FROM\n      job j\n    WHERE \n      j.id = '[[id]]'\n    ) as foo2 order by date asc\n) as foo\n  \n\n",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Memory use",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:828",
+          "format": "decmbytes",
+          "label": "Memory use",
+          "logBase": 2,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:829",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "infrabox",
+      "description": "Graphical representation of the CPU frequency of the job as registered in the database.",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "hideTimeOverride": true,
+      "id": 2,
+      "legend": {
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "$$hashKey": "object:1600",
+          "alias": "",
+          "format": "time_series",
+          "hide": false,
+          "rawSql": "SELECT\n  $__time(date),\n  cpu::float*1024 as cpu\nFROM (\n  select to_timestamp((elm::jsonb->'date')::text::int) as date, elm::jsonb->>'cpu'::text as cpu from (\n    select\n      jsonb_array_elements(j.stats::jsonb->'[[id]]') as elm\n    FROM\n      job j\n    WHERE \n      j.id = '[[id]]'\n    ) as foo2 order by date asc\n) as foo\n  \n\n",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CPU  use",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1616",
+          "format": "hertz",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1617",
+          "format": "dateTimeAsIso",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 12,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "message",
+      "targets": [
+        {
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "select message from job where id = '[[id]]'",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "MESSAGE",
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": "7ee5fa36-deca-4e32-9cb8-a8ee64ca92db",
+          "value": "7ee5fa36-deca-4e32-9cb8-a8ee64ca92db"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "id",
+        "options": [
+          {
+            "selected": true,
+            "text": "7ee5fa36-deca-4e32-9cb8-a8ee64ca92db",
+            "value": "7ee5fa36-deca-4e32-9cb8-a8ee64ca92db"
+          }
+        ],
+        "query": "7ee5fa36-deca-4e32-9cb8-a8ee64ca92db",
+        "type": "custom"
+      }
+    ]
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Job Inspector",
+  "uid": "EivX9TIiz",
+  "version": 1
+}

--- a/src/grafana/dashboards/project_inspector.json
+++ b/src/grafana/dashboards/project_inspector.json
@@ -1,0 +1,1107 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "$$hashKey": "object:87",
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "This dashboard offers a more detailed inspection of the selected project.",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 2,
+  "iteration": 1529672685877,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 25,
+      "panels": [],
+      "title": "General Information",
+      "type": "row"
+    },
+    {
+      "columns": [],
+      "datasource": "infrabox",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 10,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "NAME",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "alias": "ID",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "id",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "alias": "Visibility",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "public",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": [
+            {
+              "text": "PUBLIC",
+              "value": "1.0"
+            },
+            {
+              "text": "PRIVATE",
+              "value": "0"
+            }
+          ]
+        },
+        {
+          "alias": "Build on push",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "build_on_push",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": [
+            {
+              "text": "TRUE",
+              "value": "1.0"
+            },
+            {
+              "text": "FALSE",
+              "value": "0"
+            }
+          ]
+        },
+        {
+          "alias": "Build on trigger",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "build_on_trigger",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": [
+            {
+              "text": "TRUE",
+              "value": "1.0"
+            },
+            {
+              "text": "FALSE",
+              "value": "0"
+            }
+          ]
+        },
+        {
+          "alias": "Collaborators",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "count",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "$$hashKey": "object:462",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "Select '[[pname]]' as name, p.id as id, p.public as public, p.build_on_push as build_on_push, p.build_on_trigger as build_on_trigger, count(c.user_id)\nfrom project p LEFT OUTER JOIN collaborator c\nON  c.project_id = p.id\nWHERE name = '[[pname]]'\nGROUP BY id",
+          "refId": "A"
+        }
+      ],
+      "title": "Project Informations",
+      "transform": "table",
+      "type": "table"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "infrabox",
+      "decimals": 2,
+      "description": "Success rate for all the jobs of the project.\n\n(TR) means that the data is computed only for  jobs which end date are in the specified time range. The default time range is the last week",
+      "format": "percentunit",
+      "gauge": {
+        "maxValue": 1,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": false
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "hideTimeOverride": true,
+      "id": 27,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "80%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "success_rate_7d",
+      "targets": [
+        {
+          "$$hashKey": "object:553",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT \n  CASE\n\t  count(j.id) filter (where j.state NOT IN ('running', 'scheduled', 'queued'))\n  WHEN\n\t  0\n  THEN\n\t\tNULL\n  ELSE \n\t\t(count(j.id) filter (where j.state = 'finished'))::float / (count(j.id) filter (where j.state NOT IN ('running', 'scheduled', 'queued')))::float\n  END as success_rate_7d\nFROM job j\nWHERE $__timeFilter(j.end_date) AND j.project_id = (select id from project where name = '[[pname]]')",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "0.8,0.9",
+      "title": "Jobs Success Rate (TR)",
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "infrabox",
+      "decimals": 2,
+      "description": "Average of the Success Rate of each build of the project.\n\n(TR) means that the data is computed only for  jobs which end date are in the specified time range. The default time range is the last week",
+      "format": "percentunit",
+      "gauge": {
+        "maxValue": 1,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": false
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 15,
+        "y": 1
+      },
+      "hideTimeOverride": true,
+      "id": 28,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "80%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "avg",
+      "targets": [
+        {
+          "$$hashKey": "object:684",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT AVG(foo.success_rate_7d) FROM (\nSELECT \n  CASE\n\t  count(j.id) filter (where j.state NOT IN ('running', 'scheduled', 'queued'))\n  WHEN\n\t  0\n  THEN\n\t\tNULL\n  ELSE \n\t\t(count(j.id) filter (where j.state = 'finished'))::float / (count(j.id) filter (where j.state NOT IN ('running', 'scheduled', 'queued')))::float\n  END as success_rate_7d\nFROM job j\nWHERE $__timeFilter(j.end_date) AND j.project_id = (select id from project where name = '[[pname]]')\nGROUP BY build_id) as foo",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "0.8,0.9",
+      "title": "AVG Build Success Rate (TR)",
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "description": "The number of builds of this project which have jobs with their end date in the specified time range (TR).\nThe default time range is the last week",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 18,
+        "y": 1
+      },
+      "hideTimeOverride": true,
+      "id": 30,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "count",
+      "targets": [
+        {
+          "$$hashKey": "object:731",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT count(DISTINCT build_id)\nFROM job\nWHERE project_id = (select id from project where name = '[[pname]]') AND $__timeFilter(end_date) AND state NOT IN ('running', 'scheduled', 'queued')",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Builds over time range (TR)",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "columns": [],
+      "datasource": "infrabox",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "id": 19,
+      "links": [],
+      "pageSize": null,
+      "repeat": null,
+      "repeatDirection": "v",
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Running jobs",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "jobs",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "Cluster name",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "cluster",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "$$hashKey": "object:810",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT c.name as cluster, count(j.id) as jobs\nFROM cluster c LEFT OUTER JOIN job j \nON j.state = 'running' ANd j.cluster_name = c.name AND j.project_id = (select id from project where name = '[[pname]]')\nGROUP BY c.name",
+          "refId": "A"
+        }
+      ],
+      "title": "Project's running jobs",
+      "transform": "table",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 12,
+      "panels": [],
+      "repeat": null,
+      "title": "Ressource use by this project",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "description": "Proportion of the allocated memory for the running jobs of this project among the total cluster capacity.\n\n\nIf All clusters are inspected, we simply compute the sum.",
+      "format": "percentunit",
+      "gauge": {
+        "maxValue": 1,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 2,
+        "x": 0,
+        "y": 7
+      },
+      "id": 17,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "80%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "?column?",
+      "targets": [
+        {
+          "$$hashKey": "object:873",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT \tCASE (\n\t\tSELECT count(id)\n\t\tFROM job\n\t\tWHERE project_id = (select id from project where name = '[[pname]]') AND state = 'running' and cluster_name LIKE [[cluster]])\n\tWHEN 0 THEN 0\n\tELSE (\n\t\tSELECT DISTINCT SUM(j.memory)::float / ((SELECT DISTINCT CASE [[cluster]] WHEN '%' THEN (SELECT sum(memory_capacity) from cluster) ELSE c.memory_capacity END)/1024)\n\t\tFROM job j, cluster c\n\t\tWHERE j.project_id = (select id from project where name = '[[pname]]') AND j.cluster_name LIKE [[cluster]] AND c.name LIKE [[cluster]] AND j.state = 'running'\n\t\tGROUP BY c.name\n\t)\nEND",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "0.8,0.95",
+      "title": "Cluster RAM use",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [],
+      "valueName": "avg"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 22,
+        "x": 2,
+        "y": 7
+      },
+      "id": 21,
+      "interval": "5s",
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "$$hashKey": "object:995",
+          "alias": "",
+          "expr": "rsc_current_count{project=\"[[pname]]\", cluster=\"[[cluster]]\", rsc=\"mem\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Allocated memory",
+          "rawSql": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Cluster's memory use - Over time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decmbytes",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "description": "Proportion of the allocated cores for the running jobs of this project among the total cluster capacity.\n\n\nIf All clusters are inspected, we simply compute the sum.",
+      "format": "percentunit",
+      "gauge": {
+        "maxValue": 1,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 2,
+        "x": 0,
+        "y": 12
+      },
+      "id": 14,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "80%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "?column?",
+      "targets": [
+        {
+          "$$hashKey": "object:931",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT \tCASE (\n\t\tSELECT count(id)\n\t\tFROM job\n\t\tWHERE project_id = (select id from project where name = '[[pname]]') AND state = 'running' and cluster_name LIKE [[cluster]])\n\tWHEN 0 THEN 0\n\tELSE (\n\t\tSELECT DISTINCT SUM(j.cpu)::float / (SELECT DISTINCT CASE [[cluster]] WHEN '%' THEN (SELECT sum(cpu_capacity) from cluster) ELSE c.cpu_capacity END)\n\t\tFROM job j, cluster c\n\t\tWHERE j.project_id = (select id from project where name = '[[pname]]') AND j.cluster_name LIKE [[cluster]] AND c.name LIKE [[cluster]] AND j.state = 'running'\n\t\tGROUP BY c.name\n\t)\nEND",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "0.8,0.95",
+      "title": "Cluster CPU use",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [],
+      "valueName": "avg"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 22,
+        "x": 2,
+        "y": 12
+      },
+      "id": 23,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "$$hashKey": "object:1059",
+          "alias": "",
+          "expr": "rsc_current_count{project=\"[[pname]]\", cluster=\"[[cluster]]\", rsc=\"cpu\"}",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Allocated cores",
+          "rawSql": "rsc_current_count{project=\"[[pname]]\", cluster=\"[[cluster]]\", rsc=\"cpu\"}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Cluster's CPU use - Over time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "Cores",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 32,
+      "panels": [],
+      "title": "Builds Overview",
+      "type": "row"
+    },
+    {
+      "columns": [],
+      "datasource": "infrabox",
+      "description": "List all the builds of this project.\n\n\nThe success rate is computed over a specific time range (TR) as the proportion of 'finished' jobs among ended jobs (ie : not queued, scheduled or running).\n\nThe default time range is the last week.",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 34,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 1,
+        "desc": true
+      },
+      "styles": [
+        {
+          "$$hashKey": "object:364",
+          "alias": "Project name",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "pname",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:365",
+          "alias": "Build Number",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "link": true,
+          "linkTargetBlank": true,
+          "linkTooltip": "Open Build Inspector",
+          "linkUrl": "d/ieOb3TSiz/build-inspector?orgId=1&var-bid=${__cell_4}",
+          "mappingType": 1,
+          "pattern": "build_number",
+          "thresholds": [],
+          "type": "number",
+          "unit": "none"
+        },
+        {
+          "$$hashKey": "object:366",
+          "alias": "Restarts",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "restart_counter",
+          "thresholds": [],
+          "type": "number",
+          "unit": "none"
+        },
+        {
+          "$$hashKey": "object:367",
+          "alias": "Success Rate (TR)",
+          "colorMode": "value",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "sr",
+          "thresholds": [
+            "0.8",
+            "0.9"
+          ],
+          "type": "number",
+          "unit": "percentunit"
+        },
+        {
+          "$$hashKey": "object:414",
+          "alias": "Build ID",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": true,
+          "linkTargetBlank": true,
+          "linkTooltip": "Open Build Inspector",
+          "linkUrl": "d/ieOb3TSiz/build-inspector?orgId=1&var-bid=${__cell}",
+          "mappingType": 1,
+          "pattern": "id",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "$$hashKey": "object:351",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT pinfo.name as pname, b.build_number, b.restart_counter, sr.sr, b.id\nFROM  (SELECT id, build_number, restart_counter FROM build WHERE project_id = (select id from project where name = '[[pname]]')) b\nLEFT OUTER JOIN (SELECT build_id,\n  CASE\n\t  count(j.id) filter (where j.state NOT IN ('running', 'scheduled', 'queued'))\n  WHEN\n\t  0\n  THEN\n\t\tNULL\n  ELSE \n\t\t(count(j.id) filter (where j.state = 'finished'))::float / (count(j.id) filter (where j.state NOT IN ('running', 'scheduled', 'queued')))::float\n  END as sr\n  FROM job j\n  WHERE j.project_id = (select id from project where name = '[[pname]]') AND $__timeFilter(j.end_date)\n  GROUP BY build_id) sr\nON sr.build_id = b.id\nLEFT JOIN (SELECT name FROM project WHERE  name = '[[pname]]') pinfo ON true\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Build List",
+      "transform": "table",
+      "type": "table"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": "hanalite-releasepack",
+          "value": "hanalite-releasepack"
+        },
+        "datasource": "infrabox",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Project Name",
+        "multi": false,
+        "name": "pname",
+        "options": [],
+        "query": "select distinct name from project order by name",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": "'%'",
+        "current": {
+          "tags": [],
+          "text": "calico",
+          "value": "calico"
+        },
+        "datasource": "infrabox",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Inspected cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": "select name from cluster",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Project Inspector",
+  "uid": "ZfQaeJSiz",
+  "version": 1
+}

--- a/src/grafana/dashboards/projects_overview.json
+++ b/src/grafana/dashboards/projects_overview.json
@@ -1,0 +1,509 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "time":{
+  	"from":"now-1w",
+	"to":"now"
+  },
+  "description": "This dashboard offers a few informations about projects and a global overview for each of them",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "infrabox",
+      "description": "Total amount of projects registered in the database",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "Number of Projects : ",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "count",
+      "targets": [
+        {
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT COUNT(id) from project",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Project Count",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "columns": [],
+      "datasource": "infrabox",
+      "description": "More detailed count of each kind of project",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 5,
+        "y": 0
+      },
+      "id": 4,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Project Type",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "type",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "COUNT",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "count",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT type, count(id)\nFROM project\nGROUP BY type",
+          "refId": "A"
+        }
+      ],
+      "title": "Detailed count",
+      "transform": "table",
+      "type": "table"
+    },
+    {
+      "columns": [],
+      "datasource": "infrabox",
+      "description": "List all the projects of the database.\n\n(TR) means that the data is computed only for runnings jobs and jobs which end date are in the specified time range.\nThe default time range is the last week.\n\n\nCPU and RAM datas are the datas allocated for each job, not their actual consumption. CPU represents the number of cores.",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 17,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 6,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 5,
+        "desc": true
+      },
+      "styles": [
+        {
+          "$$hashKey": "object:488",
+          "alias": "NAME",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": true,
+          "linkTooltip": "Open Project Inspector",
+          "linkUrl": "d/ZfQaeJSiz/project-inspector?orgId=1&var-pname=${__cell}",
+          "mappingType": 1,
+          "pattern": "name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        },
+        {
+          "$$hashKey": "object:489",
+          "alias": "ID",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "id",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:490",
+          "alias": "TYPE",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "type",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:491",
+          "alias": "Visibility",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "public",
+          "preserveFormat": false,
+          "sanitize": false,
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": [
+            {
+              "text": "Public",
+              "value": "1.0"
+            },
+            {
+              "text": "Private",
+              "value": "0"
+            }
+          ]
+        },
+        {
+          "$$hashKey": "object:492",
+          "alias": "Success rate (TR)",
+          "colorMode": "value",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "success_rate_7d",
+          "thresholds": [
+            "0.8",
+            "0.9"
+          ],
+          "type": "number",
+          "unit": "percentunit"
+        },
+        {
+          "$$hashKey": "object:493",
+          "alias": "Running jobs",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "jobs_runnings",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:494",
+          "alias": "Failed jobs (TR)",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "failed_jobs_7d",
+          "thresholds": [],
+          "type": "number",
+          "unit": "locale"
+        },
+        {
+          "$$hashKey": "object:495",
+          "alias": "Collaborators",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "collabs",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:496",
+          "alias": "AVG CPU (TR)",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "avg_cpu",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:497",
+          "alias": "MIN CPU (TR)",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "min_cpu",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:498",
+          "alias": "MAX CPU (TR)",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "max_cpu",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:499",
+          "alias": "AVG RAM (TR)",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "avg_mem",
+          "thresholds": [],
+          "type": "number",
+          "unit": "decmbytes"
+        },
+        {
+          "$$hashKey": "object:500",
+          "alias": "MIN RAM (TR)",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "min_mem",
+          "thresholds": [],
+          "type": "number",
+          "unit": "decmbytes"
+        },
+        {
+          "$$hashKey": "object:501",
+          "alias": "MAX RAM (TR)",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "max_mem",
+          "thresholds": [],
+          "type": "number",
+          "unit": "decmbytes"
+        }
+      ],
+      "targets": [
+        {
+          "$$hashKey": "object:222",
+          "alias": "",
+          "format": "table",
+          "hide": false,
+          "rawSql": "SELECT \tp.name, p.type, p.public, \n\tj_infos.jobs_runnings as jobs_runnings,\n\tj_infos.failed_jobs_7d as failed_jobs_7d,\n\tj_infos.success_rate_7d as success_rate_7d,\n\tc_infos.collabs as collabs,\n\tj_infos.avg_cpu as avg_cpu,\n\tj_infos.min_cpu as min_cpu,\n\tj_infos.max_cpu as max_cpu,\n\tj_infos.avg_mem as avg_mem,\n\tj_infos.min_mem as min_mem,\n\tj_infos.max_mem as max_mem,\n\tp.id\nFROM project p LEFT OUTER JOIN \n(SELECT\n\tj.project_id,\n\tcount(j.id) filter (where j.state = 'running') as jobs_runnings,\n\tcount(j.id) filter (where (j.state IN ('failure', 'error')) and $__timeFilter(j.end_date)) as failed_jobs_7d,\n\tCASE\n\t  count(j.id) filter (where j.state NOT IN ('running', 'scheduled', 'queued') and $__timeFilter(j.end_date))\n\tWHEN\n\t  0\n\tTHEN\n\t\tNULL\n\tELSE \n\t\t(count(j.id) filter (where (j.state = 'finished' and $__timeFilter(j.end_date))))::float / (count(j.id) filter (where j.state NOT IN ('running', 'scheduled', 'queued') and $__timeFilter(j.end_date)))::float\n\tEND as success_rate_7d,\n\tavg(j.cpu) filter (where $__timeFilter(j.end_date) OR j.state = 'running') as avg_cpu,\n\tmin(j.cpu) filter (where $__timeFilter(j.end_date) OR j.state = 'running') as min_cpu,\n\tmax(j.cpu) filter (where $__timeFilter(j.end_date) OR j.state = 'running') as max_cpu,\n\tavg(j.memory) filter (where $__timeFilter(j.end_date) OR j.state = 'running') as avg_mem,\n\tmin(j.memory) filter (where $__timeFilter(j.end_date) OR j.state = 'running') as min_mem,\n\tmax(j.memory) filter (where $__timeFilter(j.end_date) OR j.state = 'running') as max_mem\nFROM\n\tjob j\n GROUP BY\n\tj.project_id) j_infos ON p.id = j_infos.project_id\nLEFT JOIN\n(SELECT project_id, count(user_id) as collabs FROM collaborator GROUP BY project_id) c_infos ON p.id = c_infos.project_id \n",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": "1w",
+      "timeShift": null,
+      "title": "Projects list",
+      "transform": "table",
+      "type": "table"
+    }
+  ],
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Projects Overview",
+  "uid": "JezmeoSiz",
+  "version": 1
+}

--- a/src/grafana/datasources/datasources.yaml
+++ b/src/grafana/datasources/datasources.yaml
@@ -1,0 +1,55 @@
+ # config file version
+apiVersion: 1
+
+
+ # list of datasources to insert/update depending
+ # on what's available in the datbase
+datasources:
+   # <string, required> name of the datasource. Required
+   # Used by the panels of the dashboards
+ - name: infrabox 
+   # <string, required> datasource type. Required
+   type: postgres
+   # <string, required> access mode. direct or proxy. Required
+   access: proxy 
+   # <int> org id. will default to orgId 1 if not specified
+   orgId: 1
+   # <string> url
+   url: IP:port
+   # <string> database name, if used
+   database: 
+   # <bool> enable/disable basic auth
+   basicAuth: false
+   # <bool> mark as default datasource. Max one per org
+   isDefault: true
+   # <map> fields that will be converted to json and stored in json_data
+   jsonData:
+       sslmode: disable
+   #   graphiteVersion: "1.1"
+   #   tlsAuth: true
+   #   tlsAuthWithCACert: true
+   ## <string> json object of data that will be encrypted.
+   secureJsonData:
+        #<string> database password, if used
+        password:  
+        #<string> database user, if used
+        user: 
+   #  tlsCACert: "..."
+   #  tlsClientCert: "..."
+   #  tlsClientKey: "..."
+   version: 1
+   # <bool> allow users to edit datasources from the UI.
+   editable: true
+
+
+ - name: prometheus
+   # <string, required> datasource type. Required
+   type: prometheus
+   # <string, required> access mode. direct or proxy. Required
+   access: proxy
+   # <int> org id. will default to orgId 1 if not specified
+   orgId: 1
+   # <string> url
+   url: http://IP:port
+   version: 1
+   editable: true 

--- a/src/pymetricserv/Dockerfile
+++ b/src/pymetricserv/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3
+
+RUN pip install psycopg2 && pip install prometheus_client
+
+COPY src/pymetricserv/ pymetricserv/
+COPY src/pyinfraboxutils /pyinfraboxutils
+
+ENV PYTHONPATH=/
+
+CMD /pymetricserv/pyserv.py
+

--- a/src/pymetricserv/pyserv.py
+++ b/src/pymetricserv/pyserv.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+import sys
+import threading
+import time
+from http.server import HTTPServer
+
+import prometheus_client
+import psycopg2
+import random
+import socket
+from subprocess import run
+from pyinfraboxutils import get_logger, get_env
+from pyinfraboxutils.db import connect_db
+from prometheus_client import Gauge, start_http_server, core
+
+
+# A little python web server which collect datas overtime from the PostgreSQL Infrabox database
+
+def execute_sql(conn, stmt, params):
+
+    c = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+    c.execute(stmt, params)
+    result = c.fetchall()
+    c.close()
+    return result
+
+
+class AllocatedRscGauge:
+    def __init__(self, name):
+        self._gauge = Gauge(name, "A gauge of allocated ressources of running jobs over time", ['cluster', 'rsc', 'project'])
+        self._request_per_cluster = "SELECT foo.cluster_name, (SELECT name FROM project WHERE id= foo.project_id), " \
+                                "foo.mem, foo.cpu FROM (SELECT cluster_name, project_id, sum(memory) as mem, " \
+                                "sum(cpu) as cpu FROM job "\
+                                "WHERE state='running' GROUP BY cluster_name, project_id) as foo"
+
+        self._request_total = "SELECT (SELECT name FROM project WHERE id = foo.project_id), foo.mem, foo.cpu " \
+                             "FROM (SELECT project_id, sum(memory) as mem, sum(cpu) as cpu "\
+                                "FROM job "\
+                                "WHERE state='running' GROUP BY project_id) as foo"
+
+    def update(self, conn):
+        per_cluster = execute_sql(conn, self._request_per_cluster, None)
+        total = execute_sql(conn, self._request_total, None)
+        self._set_values(per_cluster, total)
+
+    def _set_values(self, per_cluster, total):
+        for row in per_cluster:
+            self._gauge.labels(rsc="mem", cluster=row[0], project=row[1]).set(row[2])
+            self._gauge.labels(rsc="cpu", cluster=row[0], project=row[1]).set(row[3])
+
+        for row in total:
+            self._gauge.labels(rsc="mem", cluster="'%'", project=row[0]).set(row[1])
+            self._gauge.labels(rsc="cpu", cluster="'%'", project=row[0]).set(row[2])
+
+class JobGauge:
+    def __init__(self, name):
+        self._gauge = Gauge(name, "A histogram of current ammount of jobs",
+                              ['state', 'cluster'])
+        self._request_per_cluster = "SELECT cluster_name, count(id) filter(WHERE state = 'running'), " \
+                                   "count(id) filter(WHERE state = 'queued'),count(id) filter(WHERE state = 'scheduled') " \
+                                   "FROM job GROUP BY cluster_name"
+
+        self._request_total = "SELECT count(id) filter(WHERE state = 'running'), " \
+                             "count(id) filter(WHERE state = 'queued'), " \
+                             "count(id) filter(WHERE state = 'scheduled') FROM job"
+
+    def update(self, conn):
+        per_cluster = execute_sql(conn, self._request_per_cluster, None)
+        total = execute_sql(conn, self._request_total, None)
+        self._set_values(per_cluster, total[0])
+
+    def _set_values(self, per_cluster, total):
+        for cluster_values in per_cluster:
+            self._gauge.labels(state="running", cluster=cluster_values[0]).set(cluster_values[1])
+            self._gauge.labels(state="queued", cluster=cluster_values[0]).set(cluster_values[2])
+            self._gauge.labels(state="scheduled", cluster=cluster_values[0]).set(cluster_values[3])
+
+        if total:
+            self._gauge.labels(state="running", cluster="'%'").set(total[0])
+            self._gauge.labels(state="queued", cluster="'%'").set(total[1])
+            self._gauge.labels(state="scheduled", cluster="'%'").set(total[2])
+
+
+def start_server(init_wait_time, threshold, port):
+    """
+    A little utility which try to launch the server, is used at least one time.
+    Could be use in the future in the TRY main statement if http server stops unexceptedly
+    :param init_wait_time:  Time to wait the first time, is incremented at each fail
+    :param threshold:       When the wait time get to this value we stop trying
+    :param port:            Port on which open the server
+    """
+    while init_wait_time <= threshold:
+        try:
+            start_http_server(int(port))
+            return True
+        except OSError:
+            # TODO find the right log where to write it
+            sys.stderr.write(
+                "Unable to start the server on the {} port\nI'll wait {}s and try again".format(port, init_wait_time))
+            time.sleep(init_wait_time)
+            init_wait_time += 1
+    return False
+
+def main():
+    # getting the env variables
+    get_env('INFRABOX_VERSION')
+    get_env('INFRABOX_DATABASE_DB')
+    get_env('INFRABOX_DATABASE_USER')
+    get_env('INFRABOX_DATABASE_PASSWORD')
+    get_env('INFRABOX_DATABASE_HOST')
+    get_env('INFRABOX_DATABASE_PORT')
+    server_port = get_env('PYMETRICSERV_PORT')
+
+    # Copied from review.py, could be changed over time
+    conn = connect_db()
+    conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+
+    # When restarting or starting on a docker container, the port can be still used at the first try
+    if not start_server(2, 5, server_port):
+        return 1
+
+    job_gauge = JobGauge('job_current_count')
+    rsc_gauge = AllocatedRscGauge('rsc_current_count')
+
+    while running:
+        try:
+            job_gauge.update(conn)
+            rsc_gauge.update(conn)
+        except psycopg2.OperationalError:
+            # the db connection closed unexpectedly
+            conn = connect_db()
+            conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+        # experimental value
+        time.sleep(1.5)
+
+
+
+if __name__ == '__main__':
+    running = True
+    main()
+
+
+
+
+


### PR DESCRIPTION
First version of the Grafana server which should allow users to monitor the behaviors of clusters, projects, builds and jobs among Infrabox.

Implements a Grafana server and Python web server. 
The Grafana server displays datas from the Postgres Infrabox DB and the Prometheus DB. 
The Python repeatedly query datas from the Postgres DB to build metrics for the Prometheus DB.