### PR TITLE
Fixed missing metrics :

### DIFF
--- a/src/metrics/server.py
+++ b/src/metrics/server.py
@@ -285,6 +285,7 @@ def main():
             old_time = time.time()
             active_job_gauge.update(conn)
             rsc_gauge.update(conn)
+            all_job_gauge(conn)
         except psycopg2.OperationalError:
             # the db connection closed unexpectedly
             conn = connect_db()


### PR DESCRIPTION
The metrics server was not updating all the metrics
it may need to resize the waiting time.