### PR TITLE
git workflow allow to clone a specific branch other than master

### DIFF
--- a/docs/job/git.md
+++ b/docs/job/git.md
@@ -22,6 +22,7 @@ An example git job definition:
 |type|true|string||Has to be "git" to include a workflow from a repository|
 |name|true|string||Name of the job|
 |clone_url|true|string||Url to clone the git repository|
+|branch|false|string|master|branch to clone initially
 |commit|true|string||branch name or commit sha|
 |depends_on|false|[Dependency Configuration](/docs/job/dependencies.md)|[]|Jobs may have dependencies. You can list all jobs which should finish before the current job may be executed.|
 |environment|false|[Environment Variables](/docs/job/env_vars.md)|{}|Can be used to set environment variables for the job.|

--- a/src/job/job.py
+++ b/src/job/job.py
@@ -1125,13 +1125,14 @@ class RunJob(Job):
             if job['type'] == "git":
                 c.header("Clone repo %s" % job['clone_url'], show=True)
                 clone_url = job['clone_url']
+                branch = job.get("branch", None)
 
                 sub_path = os.path.join('.infrabox', 'tmp', job_name)
                 new_repo_path = os.path.join(self.mount_repo_dir, sub_path)
                 c.execute(['rm', '-rf', new_repo_path])
                 os.makedirs(new_repo_path)
 
-                self.clone_repo(job['commit'], clone_url, None, None, True, sub_path)
+                self.clone_repo(job['commit'], clone_url, branch, None, True, sub_path)
 
                 c.header("Parsing infrabox file", show=True)
                 ib_file = job.get('infrabox_file', None)


### PR DESCRIPTION
When specifying commit as a commit sha, then this commit cannot be
fetched, therefore it has to be in the history, which is cloned.