### PR TITLE
Add support for Kube-Lego for TLS with ingress

### DIFF
--- a/deploy/infrabox/templates/ingress.yaml
+++ b/deploy/infrabox/templates/ingress.yaml
@@ -52,6 +52,9 @@ metadata:
         nginx.ingress.kubernetes.io/session-cookie-name: "route"
         nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        {{ if .Values.ingress.use_kube_lego }}
+        kubernetes.io/tls-acme: "true"
+        {{ end }}
 spec:
     rules:
     -

--- a/deploy/infrabox/values.yaml
+++ b/deploy/infrabox/values.yaml
@@ -69,6 +69,9 @@ ingress:
     # If enabled an Ingress will be created
     enabled: true
 
+    # Use Kube-Lego (tls-acme) annotation for TLS
+    use_kube_lego: true
+
 # Exactly one storage option has to be enabled
 storage:
     gcs:

--- a/deploy/infrabox/values.yaml
+++ b/deploy/infrabox/values.yaml
@@ -70,7 +70,7 @@ ingress:
     enabled: true
 
     # Use Kube-Lego (tls-acme) annotation for TLS
-    use_kube_lego: true
+    use_kube_lego: false
 
 # Exactly one storage option has to be enabled
 storage:


### PR DESCRIPTION
This allows the annotation for autoconfiguring TLS with [Kube Lego](https://blog.jetstack.io/blog/kube-lego/) to be added.

I didn't update the docs because I'm not sure if it's better to add a new section or to replace the cert manager part with this method.