### PR TITLE
Remove http from S3 endpoint for Docker registry

### DIFF
--- a/deploy/infrabox/templates/docker-registry/deployment.yaml
+++ b/deploy/infrabox/templates/docker-registry/deployment.yaml
@@ -72,7 +72,7 @@ spec:
                     value: {{ .Values.storage.s3.region }}
                 -
                     name: REGISTRY_STORAGE_S3_REGIONENDPOINT
-                    value: http://{{ .Values.storage.s3.endpoint }}:{{ .Values.storage.s3.port }}
+                    value: {{ .Values.storage.s3.endpoint }}:{{ .Values.storage.s3.port }}
                 -
                     name: REGISTRY_STORAGE_S3_SECURE
                     value: {{ .Values.storage.s3.secure | quote }}

--- a/deploy/infrabox/values.yaml
+++ b/deploy/infrabox/values.yaml
@@ -91,7 +91,7 @@ storage:
         # Region
         region: # <REQUIRED>
 
-        # Regeion endpoint
+        # Region endpoint
         endpoint: # <REQUIRED>
 
         # Region endpoint port


### PR DESCRIPTION
This was causing issues where the registry could not connect to S3 over a secure connection (it was setting it to `http://hostname:443` and failing). Removing the protocol resolved the issue, and should continue to work because the `REGISTRY_STORAGE_S3_SECURE` is the flag for the protocol.