### PR TITLE
Store email address as lower case

### DIFF
--- a/src/api/handlers/account/account.py
+++ b/src/api/handlers/account/account.py
@@ -36,7 +36,7 @@ class Login(Resource):
         '''
         b = request.get_json()
 
-        email = b['email']
+        email = b['email'].lower()
         password = b['password']
 
         user = g.db.execute_one_dict('''
@@ -80,7 +80,7 @@ class Register(Resource):
 
         b = request.get_json()
 
-        email = b['email']
+        email = b['email'].lower()
         password1 = b['password1']
         password2 = b['password2']
         username = b['username']

--- a/src/api/handlers/account/account_ldap.py
+++ b/src/api/handlers/account/account_ldap.py
@@ -79,7 +79,7 @@ class Login(Resource):
     def post(self):
         b = request.get_json()
 
-        email = b['email']
+        email = b['email'].lower()
         password = b['password']
 
         user = g.db.execute_one_dict('''

--- a/src/db/migrations/00026.sql
+++ b/src/db/migrations/00026.sql
@@ -1,0 +1,4 @@
+ALTER TABLE ONLY "user"
+    ADD CONSTRAINT user_email_index UNIQUE (email);
+
+UPDATE "user" SET email = lower(email);


### PR DESCRIPTION
It was possible to write an email with different lower/upper case
letters. All different combinations resulted in a different user being
created in the database. Always storing the email in lower case should
ensure that a unique email address maps also only to one user.