### PR TITLE
fix job count limits to 100 running jobs

### DIFF
--- a/src/api/handlers/job_api.py
+++ b/src/api/handlers/job_api.py
@@ -762,7 +762,7 @@ class CreateJobs(Resource):
                 SELECT build_id
                 FROM job
                 WHERE id = %s
-            )
+            ) AND state in ['running', 'queued', 'scheduled']
         """, [parent_job_id])
 
         total_jobs = result[0] + len(jobs)


### PR DESCRIPTION
Currently we limit all job counts of a build to 100.
This will stop parent job from restarting if child jobs count > 50