### PR TITLE
Use new GCR authentication method

### DIFF
--- a/src/job/job.py
+++ b/src/job/job.py
@@ -945,7 +945,7 @@ class RunJob(Job):
                     sa.write(reg['service_account'])
 
                 c.execute(['gcloud', 'auth', 'activate-service-account', '--key-file', '/tmp/gcr_sa.json'], show=True)
-                c.execute(['gcloud', 'docker', '-a'], show=True)
+                c.execute(['gcloud', 'auth', 'configure-docker'], show=True)
             elif reg['type'] == 'docker-registry' and 'username' in reg:
                 cmd = ['docker', 'login', '-u', reg['username'], '-p', reg['password']]
 


### PR DESCRIPTION
The `gcloud docker` commands are deprecated and give a warning:
```
15:16:28|gcloud auth activate-service-account --key-file /tmp/gcr_sa.json
15:16:29|Activated service account credentials for: [<snip>]
15:16:29|gcloud docker -a
15:16:29|WARNING: `gcloud docker` will not be supported for Docker client versions above 18.03.
15:16:29|
15:16:29|As an alternative, use `gcloud auth configure-docker` to configure `docker` to
15:16:29|use `gcloud` as a credential helper, then use `docker` as you would for non-GCR
15:16:29|registries, e.g. `docker pull gcr.io/project-id/my-image`. Add
15:16:29|`--verbosity=error` to silence this warning: `gcloud docker
15:16:29|--verbosity=error -- pull gcr.io/project-id/my-image`.
15:16:29|
15:16:29|See: https://cloud.google.com/container-registry/docs/support/deprecation-notices#gcloud-docker
15:16:29|
15:16:29|Short-lived access for [u'gcr.io', u'us.gcr.io', u'eu.gcr.io', u'asia.gcr.io', u'staging-k8s.gcr.io', u'marketplace.gcr.io'] configured.
```

This pull request changes to Google's recommendation.