### PR TITLE
Add archive endpoint to project api

### DIFF
--- a/infrabox/test/api/project_test.py
+++ b/infrabox/test/api/project_test.py
@@ -1,3 +1,6 @@
+import json
+from os import getcwd
+
 from temp_tools import TestClient
 from test_template import ApiTestTemplate
 
@@ -13,3 +16,45 @@ class ProjectTest(ApiTestTemplate):
     def test_get_project(self):
         r = TestClient.get('/api/v1/projects/%s' % self.project_id, TestClient.get_user_authorization(self.user_id))
         self.assertEqual(r['id'], self.project_id)
+
+    def test_get_archive_missing_required_argument(self):
+        r = TestClient.get('/api/v1/projects/%s/archive?filename=foo' % self.project_id, TestClient.get_user_authorization(self.user_id))
+        self.assertIn('was not found on the server', r['message'])
+
+    def test_get_archive_missing_permissions(self):
+        r = TestClient.get('/api/v1/projects/%s/archive?filename=foo' % self.project_id_no_collab, TestClient.get_user_authorization(self.user_id))
+        self.assertIn('Unauthorized', r['message'])
+
+    def test_get_archive_does_not_exist(self):
+        r = TestClient.get('/api/v1/projects/%s/archive?filename=foo&job_name=bar' % self.project_id, TestClient.get_user_authorization(self.user_id))
+        self.assertIn('was not found on the server', r['message'])
+
+    def test_get_archive(self):
+        filename = 'test.json'
+        file_path = getcwd() + '/' + filename
+        test_content = {'foo':'bar'}
+        with open(file_path, 'w+') as test_data:
+            json.dump({'foo':'bar'}, test_data)
+            test_data.flush()
+            test_data.seek(0)
+            files = {filename: test_data}
+            r = TestClient.post('/api/job/archive', data=files, headers=TestClient.get_job_authorization(self.job_id_running),
+                                content_type='multipart/form-data')
+            self.assertEqual(r.get('message'), 'File uploaded')
+        # upload project
+        r = TestClient.get('/api/v1/projects/%s/archive?filename=test.json&job_name=running_job' % self.project_id, TestClient.get_user_authorization(self.user_id))
+        self.assertEqual(test_content, json.loads(r.data))
+        r = TestClient.get('/api/v1/projects/%s/archive?filename=test.json&job_name=running_job&branch=foo' % self.project_id, TestClient.get_user_authorization(self.user_id))
+        self.assertEqual(test_content, json.loads(r.data))
+
+        # github project
+        TestClient.execute("""
+            UPDATE project SET type='github' WHERE id=%s
+        """, [self.project_id])
+        r = TestClient.get('/api/v1/projects/%s/archive?filename=test.json&job_name=running_job&branch=foo' % self.project_id, TestClient.get_user_authorization(self.user_id))
+        self.assertIn('was not found on the server', r['message'])
+        r = TestClient.get('/api/v1/projects/%s/archive?filename=test.json&job_name=running_job&branch=branch1' % self.project_id, TestClient.get_user_authorization(self.user_id))
+        self.assertEqual(test_content, json.loads(r.data))
+
+    def test_get_archive_for_branch(self):
+        pass

--- a/infrabox/test/api/test.py
+++ b/infrabox/test/api/test.py
@@ -18,19 +18,18 @@ from pyinfraboxutils.storage import storage
 
 if __name__ == '__main__':
     storage.create_buckets()
-
     with open('results.xml', 'wb') as output:
         suite = unittest.TestSuite()
         #unittest.main(testRunner=xmlrunner.XMLTestRunner(output=output))
-        suite.addTest(unittest.TestLoader().loadTestsFromTestCase(ProjectTest))
-        suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TriggerTest))
-        suite.addTest(unittest.TestLoader().loadTestsFromTestCase(JobApiTest))
-        suite.addTest(unittest.TestLoader().loadTestsFromTestCase(BuildTest))
-        suite.addTest(unittest.TestLoader().loadTestsFromTestCase(JobTest))
-        suite.addTest(unittest.TestLoader().loadTestsFromTestCase(CollaboratorsTest))
-        suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TokensTest))
-        suite.addTest(unittest.TestLoader().loadTestsFromTestCase(SecretsTest))
-        suite.addTest(unittest.TestLoader().loadTestsFromTestCase(UserTest))
+        suite.addTests(unittest.TestLoader().loadTestsFromTestCase(ProjectTest))
+        suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TriggerTest))
+        suite.addTests(unittest.TestLoader().loadTestsFromTestCase(JobApiTest))
+        suite.addTests(unittest.TestLoader().loadTestsFromTestCase(BuildTest))
+        suite.addTests(unittest.TestLoader().loadTestsFromTestCase(JobTest))
+        suite.addTests(unittest.TestLoader().loadTestsFromTestCase(CollaboratorsTest))
+        suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TokensTest))
+        suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SecretsTest))
+        suite.addTests(unittest.TestLoader().loadTestsFromTestCase(UserTest))
 
         testRunner = XMLTestRunner(output=output)
         #unittest.main(testRunner = XMLTestRunner(output=output),

--- a/infrabox/test/api/test_template.py
+++ b/infrabox/test/api/test_template.py
@@ -23,11 +23,14 @@ class ApiTestTemplate(unittest.TestCase):
         TestClient.execute('TRUNCATE auth_token')
 
         self.project_id = '1514af82-3c4f-4bb5-b1da-a89a0ced5e6f'
+        self.project_id_github = '1614af82-3c4f-4bb5-b1da-a89a0ced5e6f'
+        self.project_id_no_collab = '1714af82-3c4f-4bb5-b1da-a89a0ced5e6f'
         self.user_id = '2514af82-3c4f-4bb5-b1da-a89a0ced5e6f'
         self.repo_id = '3514af82-3c4f-4bb5-b1da-a89a0ced5e6f'
         self.build_id = '4514af82-3c4f-4bb5-b1da-a89a0ced5e6f'
         self.job_id = '1454af82-4c4f-4bb5-b1da-a54a0ced5e6f'
         self.job_id_2 = '1554af82-4c4f-4bb5-b1da-a54a0ced5e6f'
+        self.job_id_running = '1554af82-4c4f-4bb5-b1da-a42a0ced5e6f'
         self.token_id = '2bbc6c34-11dd-448c-a678-7209a071b12a'
         self.job_name = 'test_job_name1'
         self.sha = 'd670460b4b4aece5915caf5c68d12f560a9fe3e4'
@@ -57,6 +60,16 @@ class ApiTestTemplate(unittest.TestCase):
                 INSERT INTO project(id, name, type)
                 VALUES (%s, 'testproject', 'upload');
             """, [self.project_id])
+
+        TestClient.execute("""
+                INSERT INTO project(id, name, type)
+                VALUES (%s, 'testproject_archive_github', 'github');
+            """, [self.project_id_github])
+
+        TestClient.execute("""
+                INSERT INTO project(id, name, type)
+                VALUES (%s, 'testproject_archive_no_collab', 'upload');
+            """, [self.project_id_no_collab])
 
         TestClient.execute('''
             INSERT INTO auth_token (id, description, scope_push, scope_pull, project_id)
@@ -91,6 +104,23 @@ class ApiTestTemplate(unittest.TestCase):
                 VALUES (%s, 'queued', %s, 'run_docker_compose',
                         %s, %s, '', 'master', %s);
             """, [self.job_id, self.build_id, self.job_name, self.project_id, json.dumps(definition)])
+
+        definition_running = {
+            'build_only': True,
+            'name': 'running_job',
+            'resources': {
+                'limits': {
+                    'cpu': 1,
+                    'memory': 512
+                }
+            }
+        }
+        TestClient.execute("""
+                INSERT INTO job (id, state, build_id, type, name, project_id,
+                                dockerfile, cluster_name, definition)
+                VALUES (%s, 'running', %s, 'run_docker_compose',
+                        'running_job', %s, '', 'master', %s);
+            """, [self.job_id_running, self.build_id, self.project_id, json.dumps(definition_running)])
 
         TestClient.execute("""
                 INSERT INTO build (id, project_id, build_number, commit_id, source_upload_id)

--- a/src/openpolicyagent/policies/project.rego
+++ b/src/openpolicyagent/policies/project.rego
@@ -65,6 +65,32 @@ allow {
     api.token.project.id = project_id
 }
 
+#Allow GET access to /api/v1/projects/<project_id>/archive for collaborators
+allow {
+    api.method = "GET"
+    api.path = ["api", "v1", "projects", project_id, "archive"]
+
+    api.token.type = "user"
+    project_collaborator([api.token.user.id, project_id])
+}
+
+#Allow GET access to /api/v1/projects/<project_id>/archive if project is public
+allow {
+    api.method = "GET"
+    api.path = ["api", "v1", "projects", project_id, "archive"]
+
+    project_public(project_id)
+}
+
+#Allow GET access to /api/v1/projects/<project_id>/archive for project tokens
+allow {
+    api.method = "GET"
+    api.path = ["api", "v1", "projects", project_id, "archive"]
+
+    api.token.type = "project"
+    api.token.project.id = project_id
+}
+
 # Allow POST access to /api/v1/projects/<project_id>/upload/<build_id>/ for project tokens
 allow {
     api.method = "POST"


### PR DESCRIPTION
This endpoint allows fetching of the most recent version of an archived
file for a given job name. Getting the last version created from a
specific branch is available via the optional 'branch' parameter.

`/api/v1/projects/<project_id>/archive?filename=<filename>&job_name=<name>`