### PR TITLE
Enable button to access the raw log as soon as any logs are available

### DIFF
--- a/src/dashboard-client/src/components/job/JobDetail.vue
+++ b/src/dashboard-client/src/components/job/JobDetail.vue
@@ -81,7 +81,7 @@
                                     <md-icon>file_download</md-icon><span class="m-l-xs">Run Local</span>
                                     <md-tooltip md-direction="bottom">Run Local</md-tooltip>
                                 </md-button>
-                                <md-button class="md-raised md-primary md-dense" v-on:click="downloadOutput()" :disabled="job.state=='running'||job.state=='queued'||job.state=='scheduled'">
+                                <md-button class="md-raised md-primary md-dense" v-on:click="downloadOutput()" :disabled="!job.hasLogsAvailable&&(job.state=='running'||job.state=='queued'||job.state=='scheduled')">
                                     <md-icon>subtitles</md-icon><span class="m-l-xs">Console Output</span>
                                     <md-tooltip md-direction="bottom">Console Output</md-tooltip>
                                 </md-button>
@@ -128,7 +128,7 @@
                                                         </md-button>
                                                     </div>
                                                     <div class="m-r-xl">
-                                                        <md-button class="md-icon-button md-primary md-raised md-dense" v-on:click="downloadOutput()" :disabled="job.state=='running'||job.state=='queued'||job.state=='scheduled'">
+                                                        <md-button class="md-icon-button md-primary md-raised md-dense" v-on:click="downloadOutput()" :disabled="!job.hasLogsAvailable&&(job.state=='running'||job.state=='queued'||job.state=='scheduled')">
                                                             <md-icon style="color: white">subtitles</md-icon>
                                                             <md-tooltip md-direction="bottom">Console Output</md-tooltip>
                                                         </md-button>

--- a/src/dashboard-client/src/models/Job.js
+++ b/src/dashboard-client/src/models/Job.js
@@ -104,6 +104,7 @@ export default class Job {
         this.archive = []
         this.currentSection = null
         this.linesProcessed = 0
+        this.hasLogsAvailable = false
         this.message = message
         this.definition = definition
         this.nodeName = nodeName
@@ -196,6 +197,10 @@ export default class Job {
 
         this.currentSection.addLine(line)
         this.linesProcessed++
+
+        if (!this.hasLogsAvailable) {
+            this.hasLogsAvailable = true
+        }
     }
 
     _addLines (lines) {


### PR DESCRIPTION
Previously the button was only enabled after the job completed, while
individual sections provided the same link as soon as more than 200
lines were written to that section.

fixes #384