### PR TITLE
Add slack hook to checker

### DIFF
--- a/deploy/infrabox/templates/checker/deployment.yaml
+++ b/deploy/infrabox/templates/checker/deployment.yaml
@@ -38,12 +38,31 @@ spec:
                 -
                     name: INFRABOX_KUBERNETES_MASTER_PORT
                     value: "443"
+                -   name: INFRABOX_CHECKER_SLACK_HOOK_URL
+                    valueFrom:
+                        secretKeyRef:
+                            name: infrabox-checker
+                            key: slack_hook_url
+                            optional: true
                 volumeMounts:
                 {{ include "mounts_rsa_private" . | indent 16 }}
                 {{ include "mounts_rsa_public" . | indent 16 }}
                 {{ include "mounts_gcs" . | indent 16 }}
+                {{ if .Values.dev.enabled }}
+                -
+                    name: code
+                    mountPath: "/checker"
+                    subPath: src/checker
+                    readOnly: true
+                -
+                    name: code
+                    mountPath: "/pyinfraboxutils"
+                    subPath: src/pyinfraboxutils
+                    readOnly: true
+                {{ end }}
             volumes:
                 {{ include "volumes_database" . | indent 16 }}
                 {{ include "volumes_rsa" . | indent 16 }}
                 {{ include "volumes_gcs" . | indent 16 }}
+                {{ include "volumes_dev" . | indent 16 }}
 {{ end }}

--- a/deploy/infrabox/templates/secrets/checker.yaml
+++ b/deploy/infrabox/templates/secrets/checker.yaml
@@ -1,0 +1,12 @@
+{{ if or .Values.ha.enabled .Values.monitoring.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: infrabox-checker
+  namespace: {{ template "system_namespace" . }}
+type: Opaque
+data:
+{{ if .Values.ha.checker_slack_hook }}
+  slack_hook_url: {{ .Values.ha.checker_slack_hook | b64enc }}
+{{ end }}
+{{ end }}

--- a/deploy/infrabox/values.yaml
+++ b/deploy/infrabox/values.yaml
@@ -46,6 +46,8 @@ ha:
 
     global_port: 443
 
+    checker_slack_hook: #<checker will report cluster status changes here if set>
+
 cluster:
     # Unique name of all clusters which are connected to the
     # same postgresql database

--- a/src/pyinfraboxutils/slack.py
+++ b/src/pyinfraboxutils/slack.py
@@ -1,0 +1,36 @@
+# Utility class for slack integration
+
+import os
+import json
+import requests
+
+from pyinfraboxutils import get_env
+
+
+class SlackHook(object):
+    @property
+    def hook_url(self):
+        return self._hook_url
+
+    def __init__(self, hook_url):
+        self._hook_url = hook_url
+
+    def send_status(self, message, mentions=None):
+        if mentions:
+            message = "{message} ({mentions})".format(message=message,
+                                                      mentions=", ".join(self._wrap_mentions(mentions)))
+        data = {
+            "text": message
+        }
+        r = requests.post(self._hook_url, data=json.dumps(data))
+        if r.status_code != 200:
+            raise Exception("Posting to slack hook failed", r.text)
+
+    @staticmethod
+    def _wrap_mentions(mentions):
+        if not isinstance(mentions, list):
+            mentions = [mentions]
+        # remove duplicates
+        mentions = list(dict.fromkeys(mentions))
+        # format names to <@name>
+        return ["<@{}>".format(m) for m in mentions]


### PR DESCRIPTION
To get notified when a cluster of a HA setup gets deactivated by
checker, a slack callback is added. As preparation for further changes
to the checker service the dev settings were enhanced and local source
directories are mounted into the pod.