### PR TITLE
add full_history for creating job.

### DIFF
--- a/src/job/job.py
+++ b/src/job/job.py
@@ -190,7 +190,12 @@ class RunJob(Job):
         c.execute(['git', 'config', 'remote.origin.url', clone_url], cwd=mount_repo_dir, show=True)
         c.execute(['git', 'config', 'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*'],
                   cwd=mount_repo_dir, show=True)
-        c.execute(['git', 'fetch', 'origin', commit], cwd=mount_repo_dir, show=True, retry=True)
+        try:
+            c.execute(['git', 'fetch', 'origin', commit], cwd=mount_repo_dir, show=True, retry=False)
+        except Exception:
+            c.collect("failed fetching commit: %s, trying to fetch full history and retry" % commit)
+            c.execute(['git', 'fetch'], cwd=mount_repo_dir, show=True, retry=True)
+            c.execute(['git', 'fetch', 'origin', commit], cwd=mount_repo_dir, show=True, retry=True)
 
         cmd = ['git', 'checkout', '-qf', commit]
 


### PR DESCRIPTION
some PR failed bacause the commit id in PR is too old.

for upload type job, we have `full_history` option in infrabox.json to enable full_history when clone repo.
for create_job_matrix job, we can't have this option, so just enable `full_history` by default.