### PR TITLE
Do not use the deprecated confirmation annotation

### DIFF
--- a/src/services/gardener/pkg/stub/shootOperations/delete.go
+++ b/src/services/gardener/pkg/stub/shootOperations/delete.go
@@ -76,7 +76,7 @@ func setDeletionConfirmation(shootInterface gardenV1beta1.ShootInterface, shootN
 	return nil
 }
 
-const confirmationAnnotationName = "confirmation.garden.sapcloud.io/deletion"
+const confirmationAnnotationName = "confirmation.gardener.cloud/deletion"
 
 func createDeletionConfirmationJPatch(shoot *v1beta1.Shoot) ([]byte, error) {
 	if shoot == nil {


### PR DESCRIPTION
`confirmation.garden.sapcloud.io` is deprecated with https://github.com/gardener/gardener/pull/1833 and will be removed in a future release of gardener/gardener.