### PR TITLE
Enhance vault UI: add role_id and secret_id

### DIFF
--- a/src/dashboard-client/src/components/project/Settings.vue
+++ b/src/dashboard-client/src/components/project/Settings.vue
@@ -12,11 +12,11 @@
         <md-layout md-column md-gutter md-flex-xsmall="100" md-flex-small="50" md-flex-medium="50" md-flex-large="50" md-flex-xlarge="50">
             <ib-project-sshkeys :project="project"></ib-project-sshkeys>
         </md-layout>
-        <md-layout md-column md-gutter md-flex-xsmall="100" md-flex-small="50" md-flex-medium="50" md-flex-large="50" md-flex-xlarge="50">
-            <ib-Vault :project="project"></ib-Vault>
-         </md-layout>
         <md-layout v-if="project.userHasOwnerRights()" md-column md-gutter md-flex-xsmall="100" md-flex-small="50" md-flex-medium="50" md-flex-large="50" md-flex-xlarge="50">
             <ib-project-visibility :project="project"></ib-project-visibility>
+        </md-layout>
+        <md-layout md-column md-gutter md-flex-xsmall="100" md-flex-small="100" md-flex-medium="100" md-flex-large="100" md-flex-xlarge="100">
+            <ib-Vault :project="project"></ib-Vault>
         </md-layout>
         <md-layout md-column md-gutter md-flex-xsmall="100" md-flex-small="100" md-flex-medium="100" md-flex-large="100" md-flex-xlarge="100">
             <ib-project-cronjobs :project="project"></ib-project-cronjobs>

--- a/src/dashboard-client/src/components/project/Vault.vue
+++ b/src/dashboard-client/src/components/project/Vault.vue
@@ -107,7 +107,7 @@ export default {
                     this.version = ''
                     this.token = ''
                     this.ca = ''
-                    this.role_id= ''
+                    this.role_id = ''
                     this.secret_id = ''
                     this.project._reloadVault()
                 })

--- a/src/dashboard-client/src/components/project/Vault.vue
+++ b/src/dashboard-client/src/components/project/Vault.vue
@@ -31,11 +31,19 @@
                             </md-input-container>
                             <md-input-container class="m-l-sm">
                               <label>Token</label>
-                              <md-textarea v-model="token" required></md-textarea>
+                              <md-textarea v-model="token"></md-textarea>
                             </md-input-container>
                             <md-input-container class="m-l-sm">
                                 <label>CA</label>
                                 <md-textarea v-model="ca"></md-textarea>
+                            </md-input-container>
+                            <md-input-container class="m-l-sm">
+                                <label>RoleId</label>
+                                <md-textarea v-model="role_id"></md-textarea>
+                            </md-input-container>
+                            <md-input-container class="m-l-sm">
+                                <label>SecretId</label>
+                                <md-textarea v-model="secret_id"></md-textarea>
                             </md-input-container>
                             <md-button class="md-icon-button md-list-action" @click="addVault()">
                                 <md-icon md-theme="running" class="md-primary">add_circle</md-icon>
@@ -70,7 +78,9 @@ export default {
         namespace: '',
         version: '',
         token: '',
-        ca: ''
+        ca: '',
+        role_id: '',
+        secret_id: ''
     }),
     created () {
         this.project._loadVault()
@@ -87,7 +97,7 @@ export default {
                 })
         },
         addVault () {
-            const d = { name: this.name, url: this.url, namespace: this.namespace, version: this.version, token: this.token, ca: this.ca }
+            const d = { name: this.name, url: this.url, namespace: this.namespace, version: this.version, token: this.token, ca: this.ca, role_id: this.role_id, secret_id: this.secret_id }
             NewAPIService.post(`projects/${this.project.id}/vault`, d)
                 .then((response) => {
                     NotificationService.$emit('NOTIFICATION', new Notification(response))
@@ -97,6 +107,8 @@ export default {
                     this.version = ''
                     this.token = ''
                     this.ca = ''
+                    this.role_id= ''
+                    this.secret_id = ''
                     this.project._reloadVault()
                 })
                 .catch((err) => {


### PR DESCRIPTION
Now the Infrabox only support get secrets with token. But token always have a short-life. The better way is to use role_id and secret_id, which is no longer expired. This PR is for adding an entrance to configure role_id and secert_id in UI.

