### PR TITLE
added API response on Vault access error

### DIFF
--- a/src/api/handlers/job_api.py
+++ b/src/api/handlers/job_api.py
@@ -303,7 +303,7 @@ class Job(Resource):
                         json_res = json.loads(res.content)
                         token = json_res['auth']['client_token']
                     else:
-                        abort(400, "Getting value from vault error: url is '%s', validate way is appRole " % (url))
+                        abort(400, "Getting value from vault error: url is '%s', validate way is appRole; API response: '%s'" % (url, res.text))
                 else:
                     abort(400, "Validate way is '%s' ! result is '%s' " % (validate_res, result))
 


### PR DESCRIPTION
# What this does
In recent usage of Vault integration via appRole, the error message was not clear enough to tell the developer the issue was an invalid `secret-id` that needed refreshing. This PR adds the full raw API response the the CI log in order to facilitate debugging.

Message was:
> Getting value from vault error: url is 'https://`<redacted>`/appRoleCredentials', validate way is appRole

It should become:
> Getting value from vault error: url is 'https://<redacted>/appRoleCredentials', validate way is appRole; API response: `<the raw response in text format>`
