### PR TITLE
feat: allowing access to manage Vault from valid project tokens

### DIFF
--- a/src/openpolicyagent/policies/projects_vault.rego
+++ b/src/openpolicyagent/policies/projects_vault.rego
@@ -6,10 +6,17 @@ import data.infrabox.collaborators.collaborators
 import data.infrabox.projects.projects
 import data.infrabox.roles
 
+# Vault admins definition
 projects_vault_administrator([user, project]){
     collaborators[i].project_id = project
     collaborators[i].user_id = user
     roles[collaborators[i].role] >= 20
+}
+
+# Project tokens definition
+valid_project_token([token, project_id]) {
+    token.type = "project"
+    token.project.id = project_id
 }
 
 # Allow GET access to /api/v1/projects/<project_id>/vault for project administrators
@@ -19,6 +26,12 @@ allow {
     api.token.type = "user"
     projects_vault_administrator([api.token.user.id, project_id])
 }
+# Allow GET access to /api/v1/projects/<project_id>/vault for valid project token
+allow {
+    api.method = "GET"
+    api.path = ["api", "v1", "projects", project_id, "vault"]
+    valid_project_token([api.token, project_id])
+}
 
 # Allow POST access to /api/v1/projects/<project_id>/vault for project administrators
 allow {
@@ -27,6 +40,12 @@ allow {
     api.token.type = "user"
     projects_vault_administrator([api.token.user.id, project_id])
 }
+# Allow POST access to /api/v1/projects/<project_id>/vault for valid project token
+allow {
+    api.method = "POST"
+    api.path = ["api", "v1", "projects", project_id, "vault"]
+    valid_project_token([api.token, project_id])
+}
 
 # Allow DELETE access to /api/v1/projects/<project_id>/vault/<vault_id> for project administrators
 allow {
@@ -34,4 +53,10 @@ allow {
     api.path = ["api", "v1", "projects", project_id, "vault", vault_id]
     api.token.type = "user"
     projects_vault_administrator([api.token.user.id, project_id])
+}
+# Allow DELETE access to /api/v1/projects/<project_id>/vault/<vault_id> for valid project token
+allow {
+    api.method = "DELETE"
+    api.path = ["api", "v1", "projects", project_id, "vault", vault_id]
+    valid_project_token([api.token, project_id])
 }


### PR DESCRIPTION
## What this does
This change in `openpolicyagent` allows us to now use valid project tokens in order to manage the Vault entry on Infrabox.

## Why we need it
So that we can programmatically update Vault when, for example, we auto-rotate the `secret-id` value used to access it. Using personal accounts to do it (e.g.: LDAP) is not ok from a security perspective as any project admin would be able to retrieve that information and impersonate the owner of such accounts.