### PR TITLE
Add INFRABOX_CRONJOB to docker build args

### DIFF
--- a/src/job/job.py
+++ b/src/job/job.py
@@ -35,7 +35,7 @@ logger = get_logger('scheduler')
 ERR_EXIT_FAILURE = 1
 ERR_EXIT_ERROR = 2
 
-BUILD_ARGS = ('GITHUB_OAUTH_TOKEN', 'GITHUB_BASE_URL')
+BUILD_ARGS = ('GITHUB_OAUTH_TOKEN', 'GITHUB_BASE_URL', 'INFRABOX_CRONJOB')
 
 def makedirs(path):
     os.makedirs(path)


### PR DESCRIPTION
Make the contents of INFRABOX_CRONJOB  (true or false) available to the docker builds.