### PR TITLE
try to fix running docker inside infrabox job

### DIFF
--- a/src/job/job.py
+++ b/src/job/job.py
@@ -906,6 +906,7 @@ class RunJob(Job):
         if privileged:
             cmd += ['--privileged']
             cmd += ['-v', '/data/inner/docker:/var/lib/docker']
+            cmd += ['-v', '/var/run/docker.sock:/var/run/docker.sock']
 
         cmd += [image_name]
 


### PR DESCRIPTION
We chose to mount docker socket to the inside container. This should be safe. One side effect could be interfering with docker starting scripts