### PR TITLE
Feat: local dev stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ src/services/namespace/vendor
 src/services/namespace/namespace
 src/services/namespace/tmp/_output/
 infrabox/local-dev/.env
+infrabox/test/api/test.json

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ src/services/gcp/tmp/_output/
 src/services/namespace/vendor
 src/services/namespace/namespace
 src/services/namespace/tmp/_output/
+infrabox/local-dev/.env

--- a/infrabox/local-dev/.env.example
+++ b/infrabox/local-dev/.env.example
@@ -1,0 +1,1 @@
+INFRABOX_DB_PASSWORD=changeme

--- a/infrabox/local-dev/Makefile
+++ b/infrabox/local-dev/Makefile
@@ -1,0 +1,20 @@
+COMPOSE = DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 \
+  docker compose -f $(CURDIR)/docker-compose.yml
+ROOT = $(CURDIR)/../..
+
+.PHONY: start stop logs frontend
+
+start:
+	@if [ ! -f .env ]; then cp .env.example .env; echo "Created .env from .env.example — edit the password before retrying."; exit 1; fi
+	$(COMPOSE) up -d
+
+stop:
+	$(COMPOSE) down
+
+logs:
+	$(COMPOSE) logs -f api
+
+frontend:
+	cd $(ROOT)/src/dashboard-client && \
+	  npm install --legacy-peer-deps --ignore-scripts && \
+	  npm run dev

--- a/infrabox/local-dev/Makefile
+++ b/infrabox/local-dev/Makefile
@@ -16,5 +16,5 @@ logs:
 
 frontend:
 	cd $(ROOT)/src/dashboard-client && \
-	  npm install --legacy-peer-deps --ignore-scripts && \
+	  npm install --ignore-scripts && \
 	  npm run dev

--- a/infrabox/local-dev/README.md
+++ b/infrabox/local-dev/README.md
@@ -3,69 +3,57 @@
 A Docker Compose environment for running the full backend stack locally,
 including PostgreSQL, MinIO, OPA, and the API server.
 
-## Before You Start
-
-**Set passwords**: the password fields in `docker-compose.yml` are left blank.
-Fill them in before starting:
-
-```yaml
-# postgres service
-- POSTGRES_PASSWORD=<your-password>
-
-# api service
-- INFRABOX_DATABASE_PASSWORD=<your-password>   # must match the value above
-```
-
-Any simple password (e.g. `postgres`) works fine for local use.
-
-## Start
+## Quick Start
 
 ```bash
-# First run: builds API, OPA, and Postgres images from source
-DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 \
-  docker compose -f infrabox/local-dev/docker-compose.yml up -d
+cd infrabox/local-dev
 
-# Follow API logs
-docker compose -f infrabox/local-dev/docker-compose.yml logs -f api
+# 1. Create your local config (only needed once)
+cp .env.example .env
+#    Edit .env and set INFRABOX_DB_PASSWORD to any value you like.
+
+# 2. Start the backend stack
+make start
+
+# 3. Start the frontend dev server (separate terminal)
+make frontend
 ```
 
-## Frontend Dev Server
+Open http://localhost:8081 (increments automatically if 8080 is taken).
+
+**Default credentials** (created by `seed.sql` on first run):
+
+| Email | Password | Role |
+|-------|----------|------|
+| admin@local.dev | admin123 | admin |
+
+Log in with the **email** address, not the username.
+
+## Other Commands
 
 ```bash
-cd src/dashboard-client
-npm install --legacy-peer-deps --ignore-scripts
-npm run dev
+make logs    # tail API logs
+make stop    # tear down all containers
 ```
 
-Open http://localhost:8081 (the port increments automatically if 8080 is taken).
+## How It Works
 
-API requests are forwarded to `http://localhost:8090` via the webpack proxyTable —
-no manual CORS configuration needed.
+- `seed.sql` is mounted into the postgres container and runs on first startup.
+  It inserts the required `cluster` row and the default admin user.
+- The API is exposed on host port `8090` (container port `8080`).
+- API requests from the frontend dev server are proxied to `http://localhost:8090`
+  via the webpack `proxyTable` — no manual CORS configuration needed.
+- RSA keys are reused from `infrabox/test/utils/id_rsa[.pub]` — local dev only.
+- OPA and API are built from source to pick up the latest policies and handlers.
 
-## Create Test Users
+## Adding More Users
 
 ```bash
-# Generate a bcrypt password hash (requires the bcrypt Python package)
+# Generate a bcrypt hash for any password
 python3 -c "import bcrypt; print(bcrypt.hashpw(b'yourpassword', bcrypt.gensalt()).decode())"
 
-# Insert a user (role: 'user' or 'admin')
 docker exec local-dev-postgres-1 psql -U postgres -c "
   INSERT INTO \"user\" (username, email, password, role)
   VALUES ('alice', 'alice@example.com', '<bcrypt-hash>', 'user');
 "
 ```
-
-Log in with the **email** address, not the username.
-
-## Stop
-
-```bash
-docker compose -f infrabox/local-dev/docker-compose.yml down
-```
-
-## Notes
-
-- `seed.sql` inserts the required `cluster` row on first startup
-- The API is exposed on host port `8090` (container port `8080`)
-- RSA keys are reused from `infrabox/test/utils/id_rsa[.pub]` — local dev only
-- OPA and API are built from source to pick up the latest policies and handlers

--- a/infrabox/local-dev/README.md
+++ b/infrabox/local-dev/README.md
@@ -1,0 +1,68 @@
+# InfraBox Local Dev Stack
+
+本目录提供一套用于本地验证后端功能的 Docker Compose 环境，包含 PostgreSQL、MinIO、OPA 和 API Server。
+
+## 启动前准备
+
+**修改密码**：`docker-compose.yml` 中密码字段已置空，启动前需要自行填入：
+
+```yaml
+# postgres 服务
+- POSTGRES_PASSWORD=<your-password>
+
+# api 服务
+- INFRABOX_DATABASE_PASSWORD=<your-password>   # 与上面保持一致
+```
+
+两处填写相同的密码即可，本地测试用简单密码（如 `postgres`）完全可以。
+
+## 启动
+
+```bash
+# 首次启动需要构建镜像（API、OPA、Postgres 均从源码构建）
+DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 \
+  docker compose -f infrabox/local-dev/docker-compose.yml up -d
+
+# 查看 API 日志
+docker compose -f infrabox/local-dev/docker-compose.yml logs -f api
+```
+
+## 前端开发服务器
+
+```bash
+cd src/dashboard-client
+npm install --legacy-peer-deps --ignore-scripts
+npm run dev
+```
+
+启动后访问 http://localhost:8081（如果 8080 被占用会自动顺延端口）。
+
+API 请求通过 webpack proxyTable 转发到 `http://localhost:8090`，无需手动配置跨域。
+
+## 创建测试用户
+
+```bash
+# 生成 bcrypt 密码 hash（Python 环境需安装 bcrypt）
+python3 -c "import bcrypt; print(bcrypt.hashpw(b'yourpassword', bcrypt.gensalt()).decode())"
+
+# 插入用户（role 可选 'user' 或 'admin'）
+docker exec local-dev-postgres-1 psql -U postgres -c "
+  INSERT INTO \"user\" (username, email, password, role)
+  VALUES ('alice', 'alice@example.com', '<bcrypt-hash>', 'user');
+"
+```
+
+登录界面填写 **email**（非 username）。
+
+## 关闭
+
+```bash
+docker compose -f infrabox/local-dev/docker-compose.yml down
+```
+
+## 说明
+
+- `seed.sql`：初始化时插入一条 `cluster` 记录，API 启动依赖该记录
+- API 对外暴露端口 `8090`，内部监听 `8080`
+- RSA 密钥复用 `infrabox/test/utils/id_rsa[.pub]`，仅供本地开发使用
+- OPA 和 API 均从源码构建，确保包含最新 policy 和 handler

--- a/infrabox/local-dev/README.md
+++ b/infrabox/local-dev/README.md
@@ -1,33 +1,35 @@
 # InfraBox Local Dev Stack
 
-本目录提供一套用于本地验证后端功能的 Docker Compose 环境，包含 PostgreSQL、MinIO、OPA 和 API Server。
+A Docker Compose environment for running the full backend stack locally,
+including PostgreSQL, MinIO, OPA, and the API server.
 
-## 启动前准备
+## Before You Start
 
-**修改密码**：`docker-compose.yml` 中密码字段已置空，启动前需要自行填入：
+**Set passwords**: the password fields in `docker-compose.yml` are left blank.
+Fill them in before starting:
 
 ```yaml
-# postgres 服务
+# postgres service
 - POSTGRES_PASSWORD=<your-password>
 
-# api 服务
-- INFRABOX_DATABASE_PASSWORD=<your-password>   # 与上面保持一致
+# api service
+- INFRABOX_DATABASE_PASSWORD=<your-password>   # must match the value above
 ```
 
-两处填写相同的密码即可，本地测试用简单密码（如 `postgres`）完全可以。
+Any simple password (e.g. `postgres`) works fine for local use.
 
-## 启动
+## Start
 
 ```bash
-# 首次启动需要构建镜像（API、OPA、Postgres 均从源码构建）
+# First run: builds API, OPA, and Postgres images from source
 DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 \
   docker compose -f infrabox/local-dev/docker-compose.yml up -d
 
-# 查看 API 日志
+# Follow API logs
 docker compose -f infrabox/local-dev/docker-compose.yml logs -f api
 ```
 
-## 前端开发服务器
+## Frontend Dev Server
 
 ```bash
 cd src/dashboard-client
@@ -35,34 +37,35 @@ npm install --legacy-peer-deps --ignore-scripts
 npm run dev
 ```
 
-启动后访问 http://localhost:8081（如果 8080 被占用会自动顺延端口）。
+Open http://localhost:8081 (the port increments automatically if 8080 is taken).
 
-API 请求通过 webpack proxyTable 转发到 `http://localhost:8090`，无需手动配置跨域。
+API requests are forwarded to `http://localhost:8090` via the webpack proxyTable —
+no manual CORS configuration needed.
 
-## 创建测试用户
+## Create Test Users
 
 ```bash
-# 生成 bcrypt 密码 hash（Python 环境需安装 bcrypt）
+# Generate a bcrypt password hash (requires the bcrypt Python package)
 python3 -c "import bcrypt; print(bcrypt.hashpw(b'yourpassword', bcrypt.gensalt()).decode())"
 
-# 插入用户（role 可选 'user' 或 'admin'）
+# Insert a user (role: 'user' or 'admin')
 docker exec local-dev-postgres-1 psql -U postgres -c "
   INSERT INTO \"user\" (username, email, password, role)
   VALUES ('alice', 'alice@example.com', '<bcrypt-hash>', 'user');
 "
 ```
 
-登录界面填写 **email**（非 username）。
+Log in with the **email** address, not the username.
 
-## 关闭
+## Stop
 
 ```bash
 docker compose -f infrabox/local-dev/docker-compose.yml down
 ```
 
-## 说明
+## Notes
 
-- `seed.sql`：初始化时插入一条 `cluster` 记录，API 启动依赖该记录
-- API 对外暴露端口 `8090`，内部监听 `8080`
-- RSA 密钥复用 `infrabox/test/utils/id_rsa[.pub]`，仅供本地开发使用
-- OPA 和 API 均从源码构建，确保包含最新 policy 和 handler
+- `seed.sql` inserts the required `cluster` row on first startup
+- The API is exposed on host port `8090` (container port `8080`)
+- RSA keys are reused from `infrabox/test/utils/id_rsa[.pub]` — local dev only
+- OPA and API are built from source to pick up the latest policies and handlers

--- a/infrabox/local-dev/README.md
+++ b/infrabox/local-dev/README.md
@@ -23,9 +23,11 @@ Open http://localhost:8081 (increments automatically if 8080 is taken).
 
 **Default credentials** (created by `seed.sql` on first run):
 
-| Email | Password | Role |
-|-------|----------|------|
-| admin@local.dev | admin123 | admin |
+| Email | Password | Role | Project access |
+|-------|----------|------|----------------|
+| admin@local.dev | admin123 | admin | — |
+| alice@local.dev | password123 | user | Owner: project-alpha, Developer: project-beta |
+| bob@local.dev | password123 | user | none |
 
 Log in with the **email** address, not the username.
 

--- a/infrabox/local-dev/docker-compose.yml
+++ b/infrabox/local-dev/docker-compose.yml
@@ -7,7 +7,7 @@ services:
             dockerfile: ./src/postgres/Dockerfile
         environment:
             - POSTGRES_USER=postgres
-            - POSTGRES_PASSWORD=
+            - POSTGRES_PASSWORD=${INFRABOX_DB_PASSWORD}
             - POSTGRES_DB=postgres
             - POSTGRES_HOST_AUTH_METHOD=trust
         volumes:
@@ -41,7 +41,7 @@ services:
             - INFRABOX_VERSION=local-dev
             - INFRABOX_DATABASE_HOST=postgres
             - INFRABOX_DATABASE_USER=postgres
-            - INFRABOX_DATABASE_PASSWORD=
+            - INFRABOX_DATABASE_PASSWORD=${INFRABOX_DB_PASSWORD}
             - INFRABOX_DATABASE_PORT=5432
             - INFRABOX_DATABASE_DB=postgres
             - INFRABOX_GENERAL_REPORT_ISSUE_URL=https://github.com/SAP/InfraBox/issues

--- a/infrabox/local-dev/docker-compose.yml
+++ b/infrabox/local-dev/docker-compose.yml
@@ -1,0 +1,87 @@
+version: "3.2"
+
+services:
+    postgres:
+        build:
+            context: ../../
+            dockerfile: ./src/postgres/Dockerfile
+        environment:
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASSWORD=
+            - POSTGRES_DB=postgres
+            - POSTGRES_HOST_AUTH_METHOD=trust
+        volumes:
+            - ./seed.sql:/docker-entrypoint-initdb.d/99_seed.sql
+        ports:
+            - "5432:5432"
+
+    minio:
+        image: minio/minio
+        command: server /data
+        environment:
+            - MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
+            - MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+        ports:
+            - "9000:9000"
+
+    opa:
+        build:
+            context: ../../
+            dockerfile: ./src/openpolicyagent/Dockerfile
+        ports:
+            - "8181:8181"
+
+    api:
+        build:
+            context: ../../
+            dockerfile: ./src/api/Dockerfile
+            args:
+                INFRABOX_BUILD_NUMBER: "3091"
+        environment:
+            - INFRABOX_VERSION=local-dev
+            - INFRABOX_DATABASE_HOST=postgres
+            - INFRABOX_DATABASE_USER=postgres
+            - INFRABOX_DATABASE_PASSWORD=
+            - INFRABOX_DATABASE_PORT=5432
+            - INFRABOX_DATABASE_DB=postgres
+            - INFRABOX_GENERAL_REPORT_ISSUE_URL=https://github.com/SAP/InfraBox/issues
+            - INFRABOX_STORAGE_GCS_ENABLED=false
+            - INFRABOX_STORAGE_AZURE_ENABLED=false
+            - INFRABOX_STORAGE_SWIFT_ENABLED=false
+            - INFRABOX_STORAGE_S3_ENABLED=true
+            - INFRABOX_STORAGE_S3_BUCKET=infrabox
+            - INFRABOX_STORAGE_S3_REGION=us-east-1
+            - INFRABOX_STORAGE_S3_SECURE=false
+            - INFRABOX_STORAGE_S3_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
+            - INFRABOX_STORAGE_S3_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+            - INFRABOX_STORAGE_S3_ENDPOINT=minio
+            - INFRABOX_STORAGE_S3_PORT=9000
+            - GOOGLE_APPLICATION_CREDENTIALS=
+            - INFRABOX_ROOT_URL=http://localhost:8090
+            - INFRABOX_CLUSTER_NAME=master
+            - INFRABOX_HA_ENABLED=false
+            - INFRABOX_OPA_HOST=opa
+            - INFRABOX_OPA_PORT=8181
+            - INFRABOX_OPA_PUSH_INTERVAL=30
+            - INFRABOX_ACCOUNT_SIGNUP_ENABLED=true
+            - INFRABOX_ACCOUNT_LDAP_ENABLED=false
+            - INFRABOX_ACCOUNT_SAML_ENABLED=false
+            - INFRABOX_LEGAL_PRIVACY_URL=
+            - INFRABOX_LEGAL_TERMS_OF_USE_URL=
+            - INFRABOX_GITHUB_ENABLED=false
+            - INFRABOX_GITHUB_LOGIN_ENABLED=false
+            - INFRABOX_GERRIT_ENABLED=false
+            - INFRABOX_LOG_LEVEL=debug
+        volumes:
+            - ../test/utils/id_rsa:/var/run/secrets/infrabox.net/rsa/id_rsa:ro
+            - ../test/utils/id_rsa.pub:/var/run/secrets/infrabox.net/rsa/id_rsa.pub:ro
+        ports:
+            - "8090:8080"
+        links:
+            - postgres
+            - minio
+            - opa
+        depends_on:
+            - postgres
+            - minio
+            - opa

--- a/infrabox/local-dev/seed.sql
+++ b/infrabox/local-dev/seed.sql
@@ -1,2 +1,6 @@
 INSERT INTO cluster (name, active, labels, root_url, nodes, cpu_capacity, memory_capacity)
 VALUES ('master', true, '{master,default}', 'http://localhost:8090', 1, 10, 10000);
+
+-- Default admin user: admin@local.dev / admin123
+INSERT INTO "user" (username, email, password, role)
+VALUES ('admin', 'admin@local.dev', '$2b$12$QxG47fCe3dqJQCjx6Z5vy./jM7/o8cZFeudhTTfcoII0IE0PmY10m', 'admin');

--- a/infrabox/local-dev/seed.sql
+++ b/infrabox/local-dev/seed.sql
@@ -4,3 +4,19 @@ VALUES ('master', true, '{master,default}', 'http://localhost:8090', 1, 10, 1000
 -- Default admin user: admin@local.dev / admin123
 INSERT INTO "user" (username, email, password, role)
 VALUES ('admin', 'admin@local.dev', '$2b$12$QxG47fCe3dqJQCjx6Z5vy./jM7/o8cZFeudhTTfcoII0IE0PmY10m', 'admin');
+
+-- Regular users: password123
+INSERT INTO "user" (id, username, email, password, role) VALUES
+  ('aaaaaaaa-0001-0001-0001-aaaaaaaaaaaa', 'alice', 'alice@local.dev', '$2b$12$oi46ZRkcmGP4A8klhxe0reHN0FBn8.N7dupNhcjP.2S6nZjlpauzq', 'user'),
+  ('aaaaaaaa-0002-0002-0002-aaaaaaaaaaaa', 'bob',   'bob@local.dev',   '$2b$12$oi46ZRkcmGP4A8klhxe0reHN0FBn8.N7dupNhcjP.2S6nZjlpauzq', 'user');
+
+-- Sample projects
+INSERT INTO project (id, name, type) VALUES
+  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'project-alpha', 'upload'),
+  ('bbbbbbbb-0002-0002-0002-bbbbbbbbbbbb', 'project-beta',  'upload'),
+  ('bbbbbbbb-0003-0003-0003-bbbbbbbbbbbb', 'project-gamma', 'upload');
+
+-- alice: Owner on alpha, Developer on beta; no access to gamma
+INSERT INTO collaborator (user_id, project_id, role) VALUES
+  ('aaaaaaaa-0001-0001-0001-aaaaaaaaaaaa', 'bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'Owner'),
+  ('aaaaaaaa-0001-0001-0001-aaaaaaaaaaaa', 'bbbbbbbb-0002-0002-0002-bbbbbbbbbbbb', 'Developer');

--- a/infrabox/local-dev/seed.sql
+++ b/infrabox/local-dev/seed.sql
@@ -1,0 +1,2 @@
+INSERT INTO cluster (name, active, labels, root_url, nodes, cpu_capacity, memory_capacity)
+VALUES ('master', true, '{master,default}', 'http://localhost:8090', 1, 10, 10000);

--- a/infrabox/test/api/docker-compose.override.yml
+++ b/infrabox/test/api/docker-compose.override.yml
@@ -1,0 +1,16 @@
+version: "3.2"
+
+services:
+    postgres:
+        environment:
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASSWORD=postgres
+            - POSTGRES_DB=postgres
+            - POSTGRES_HOST_AUTH_METHOD=trust
+
+    test:
+        build:
+            args:
+                INFRABOX_BUILD_NUMBER: "3091"
+        volumes:
+            - ../../../:/infrabox/context


### PR DESCRIPTION
## Summary

Adds a self-contained Docker Compose dev stack under `infrabox/local-dev/` so contributors can run the full backend locally without a Kubernetes cluster.

- **`docker-compose.yml`** — spins up PostgreSQL (built from `src/postgres/Dockerfile` with migrations), MinIO (S3-compatible storage), OPA, and the API server; API exposed on host port `8090`
- **`seed.sql`** — pre-populates the DB with a cluster row, an `admin` user, two regular users (`alice`, `bob`), and sample projects with collaborator assignments for testing access-control scenarios
- **`Makefile`** — `make start / stop / logs / frontend`; `start` guard checks for `.env` before bringing up containers
- **`.env.example`** — template with `INFRABOX_DB_PASSWORD`; copied to `.env` (git-ignored) on first run
- **`README.md`** — quick-start guide, default credentials table, how the webpack proxy wires the frontend to the local API, and instructions for adding more users
- **`.gitignore`** — ignore `infrabox/local-dev/.env` and `infrabox/test/api/test.json`
- **`infrabox/test/api/docker-compose.override.yml`** — Compose override that injects the repo root as a volume into the API test container, removing the need to rebuild the image on every code change

## Test plan

- [ ] `cd infrabox/local-dev && make start` — all four containers come up healthy
- [ ] `make frontend` — webpack dev server starts and proxies API calls to `http://localhost:8090`
- [ ] Login with `admin@local.dev / admin123` and `alice@local.dev / password123` in the browser
- [ ] Alice sees `project-alpha` and `project-beta`; Bob sees no projects (correct by seed data)
- [ ] `make stop` tears down all containers cleanly
- [ ] Missing `.env` causes `make start` to print an actionable error and exit without starting containers