### PR TITLE
chore: enable image cache for service-gcp CI job

### DIFF
--- a/infrabox/generator/deployments.json
+++ b/infrabox/generator/deployments.json
@@ -487,6 +487,9 @@
                     "memory": 2048
                 }
             },
+            "cache": {
+                "image": true
+            },
             "deployments": [
                 {
                     "type": "docker-registry",


### PR DESCRIPTION
## Summary

Enable Docker layer cache for the `ib/deploy/service-gcp` CI job.

The job currently runs without cache (`cache.image: false` by default), causing it to re-download ~250MB of external dependencies on every build:
- Google Cloud SDK 408.0.0 (155MB) from dl.google.com
- kubectl + gcloud beta components (~100MB) via gcloud components install
- Go dependencies via `dep ensure` (6 min)

All of these are pure environment layers unrelated to source code. With `cache.image: true`, Docker will reuse these layers across builds. The `COPY . /go/src/...` step still invalidates cache on any code change, so the latest code always enters the image correctly.