### PR TITLE
chore: force api image layer cache invalidation

### DIFF
--- a/src/api/handlers/mcp/routes/jobs.py
+++ b/src/api/handlers/mcp/routes/jobs.py
@@ -133,3 +133,4 @@ def _job_dict(r):
         'end_date': r['end_date'].isoformat() if r.get('end_date') else None,
         'message': r.get('message'),
     }
+


### PR DESCRIPTION
The `COPY src/api` Docker layer was being reused from quay.io cache even after code changes, because the layer content hash happened to match a previously pushed layer. Adding a trailing newline to `jobs.py` changes the layer hash and forces a fresh push.