### PR TITLE
feat: add MCP token management UI to My Tokens page

### DIFF
--- a/src/api/handlers/mcp/auth.py
+++ b/src/api/handlers/mcp/auth.py
@@ -116,6 +116,10 @@ def check_project_access_mcp(project_id: str) -> bool:
         return True
 
     enabled = g.mcp_enabled_projects
+    if not enabled:
+        # empty dict = all projects allowed
+        return True
+
     if project_id not in enabled:
         return False
 

--- a/src/api/handlers/mcp/auth.py
+++ b/src/api/handlers/mcp/auth.py
@@ -107,6 +107,10 @@ def mcp_auth_required(f):
 def check_project_access_mcp(project_id: str) -> bool:
     """Return True if the current request may access project_id.
 
+    enabled_projects semantics (intentional):
+      {}          → allow all projects (user chose no restriction when creating the token)
+      {id: ...}   → allow only the listed project IDs
+
     MCP token path: project must be in g.mcp_enabled_projects and not past
     its per-project expiry (if set).
     Session path: delegates to OPA (already checked in before_request).
@@ -117,7 +121,7 @@ def check_project_access_mcp(project_id: str) -> bool:
 
     enabled = g.mcp_enabled_projects
     if not enabled:
-        # empty dict = all projects allowed
+        # empty dict → no project restriction, allow all
         return True
 
     if project_id not in enabled:

--- a/src/api/handlers/mcp/routes/projects.py
+++ b/src/api/handlers/mcp/routes/projects.py
@@ -27,21 +27,24 @@ class MCPProjects(Resource):
             enabled = getattr(g, 'mcp_enabled_projects', None)
 
             if enabled is not None:
-                # MCP token path: return only scoped projects where the token owner
-                # is still a collaborator — re-validate membership at query time so
-                # a revoked collaborator cannot enumerate project metadata.
+                # MCP token path
                 if not enabled:
-                    audit_mcp('list_projects', outcome='success', details={'count': 0})
-                    return []
-
-                project_ids = list(enabled.keys())
-                rows = g.db.execute_many_dict('''
-                    SELECT p.id, p.name, p.type, p.public
-                    FROM project p
-                    INNER JOIN collaborator co ON co.project_id = p.id AND co.user_id = %s
-                    WHERE p.id = ANY(%s::uuid[])
-                    ORDER BY p.name
-                ''', [user_id, project_ids])
+                    # empty dict = all projects the user is a collaborator on
+                    rows = g.db.execute_many_dict('''
+                        SELECT p.id, p.name, p.type, p.public
+                        FROM project p
+                        INNER JOIN collaborator co ON co.project_id = p.id AND co.user_id = %s
+                        ORDER BY p.name
+                    ''', [user_id])
+                else:
+                    project_ids = list(enabled.keys())
+                    rows = g.db.execute_many_dict('''
+                        SELECT p.id, p.name, p.type, p.public
+                        FROM project p
+                        INNER JOIN collaborator co ON co.project_id = p.id AND co.user_id = %s
+                        WHERE p.id = ANY(%s::uuid[])
+                        ORDER BY p.name
+                    ''', [user_id, project_ids])
             else:
                 # Session path: return all projects the user is a collaborator on
                 rows = g.db.execute_many_dict('''

--- a/src/api/handlers/mcp/routes/projects.py
+++ b/src/api/handlers/mcp/routes/projects.py
@@ -61,3 +61,4 @@ class MCPProjects(Resource):
         except Exception as exc:
             audit_mcp('list_projects', outcome='failure', error=str(exc))
             raise
+

--- a/src/dashboard-client/src/components/user/UserGlobalTokens.vue
+++ b/src/dashboard-client/src/components/user/UserGlobalTokens.vue
@@ -254,7 +254,7 @@
                             </md-table-cell>
                             <md-table-cell>{{ t.last_used_at ? formatDate(t.last_used_at) : '—' }}</md-table-cell>
                             <md-table-cell>
-                                <md-switch :value="t.allow_trigger" @change="toggleMcpTrigger(t)" class="mcp-trigger-switch"></md-switch>
+                                <md-switch v-model="t.allow_trigger" @change="toggleMcpTrigger(t)" class="mcp-trigger-switch"></md-switch>
                             </md-table-cell>
                             <md-table-cell>
                                 <md-button class="md-icon-button" @click="confirmMcpRevoke(t)">

--- a/src/dashboard-client/src/components/user/UserGlobalTokens.vue
+++ b/src/dashboard-client/src/components/user/UserGlobalTokens.vue
@@ -186,6 +186,115 @@
             md-cancel-text="Cancel"
             @close="onRevokeClose">
         </md-dialog-confirm>
+
+        <!-- ===== MCP Tokens ===== -->
+        <md-card class="main-card" style="margin-top: 16px">
+            <md-card-header class="main-card-header fix-padding">
+                <md-card-header-text>
+                    <h3 class="md-title card-title">
+                        <md-layout>
+                            <md-layout md-vertical-align="center">MCP Tokens</md-layout>
+                            <md-layout md-vertical-align="center">
+                                <small class="section-hint">For use with the InfraBox MCP server (INFRABOX_MCP_TOKEN)</small>
+                            </md-layout>
+                        </md-layout>
+                    </h3>
+                </md-card-header-text>
+            </md-card-header>
+
+            <!-- Create form -->
+            <md-card md-theme="white" class="clean-card">
+                <md-card-area>
+                    <md-list class="m-t-md m-b-md">
+                        <md-list-item>
+                            <md-input-container class="m-r-sm" style="flex: 2">
+                                <label>Token Name (e.g. "Claude Desktop")</label>
+                                <md-input v-model="mcpForm.name" @keyup.enter.native="createMcpToken"></md-input>
+                            </md-input-container>
+                            <md-input-container class="m-r-sm" style="flex: 0 0 160px">
+                                <label>Validity (days)</label>
+                                <md-input v-model.number="mcpForm.expiresDays" type="number" min="1" max="365" placeholder="365"></md-input>
+                            </md-input-container>
+                            <md-button :disabled="disableMcpAdd" class="md-icon-button md-list-action" @click="createMcpToken">
+                                <md-icon md-theme="running" class="md-primary">add_circle</md-icon>
+                                <md-tooltip>Create MCP token</md-tooltip>
+                            </md-button>
+                        </md-list-item>
+                    </md-list>
+                </md-card-area>
+            </md-card>
+
+            <!-- Token list -->
+            <md-table-card class="clean-card">
+                <md-table>
+                    <md-table-header>
+                        <md-table-row>
+                            <md-table-head>Name</md-table-head>
+                            <md-table-head>Projects</md-table-head>
+                            <md-table-head>Created</md-table-head>
+                            <md-table-head>Expires</md-table-head>
+                            <md-table-head>Last Used</md-table-head>
+                            <md-table-head>Trigger</md-table-head>
+                            <md-table-head>Actions</md-table-head>
+                        </md-table-row>
+                    </md-table-header>
+                    <md-table-body>
+                        <md-table-row v-for="t in mcpTokens" :key="t.token_id">
+                            <md-table-cell>{{ t.name }}</md-table-cell>
+                            <md-table-cell>
+                                <span v-if="!t.enabled_projects || Object.keys(t.enabled_projects).length === 0" class="mcp-all-projects">all projects</span>
+                                <span v-else class="mcp-project-count">{{ Object.keys(t.enabled_projects).length }} project(s)</span>
+                            </md-table-cell>
+                            <md-table-cell>{{ formatDate(t.created_at) }}</md-table-cell>
+                            <md-table-cell>
+                                <span :class="expiryClass(t.expires_at)">
+                                    {{ formatDate(t.expires_at) }}
+                                    <md-icon v-if="isExpiringSoon(t.expires_at)" style="font-size:16px;vertical-align:middle">warning</md-icon>
+                                </span>
+                            </md-table-cell>
+                            <md-table-cell>{{ t.last_used_at ? formatDate(t.last_used_at) : '—' }}</md-table-cell>
+                            <md-table-cell>
+                                <md-switch :value="t.allow_trigger" @change="toggleMcpTrigger(t)" class="mcp-trigger-switch"></md-switch>
+                            </md-table-cell>
+                            <md-table-cell>
+                                <md-button class="md-icon-button" @click="confirmMcpRevoke(t)">
+                                    <md-icon class="md-primary">delete</md-icon>
+                                    <md-tooltip>Revoke token</md-tooltip>
+                                </md-button>
+                            </md-table-cell>
+                        </md-table-row>
+
+                        <md-table-row v-if="mcpTokens.length === 0">
+                            <md-table-cell colspan="7">No MCP tokens yet. Create one above.</md-table-cell>
+                        </md-table-row>
+                    </md-table-body>
+                </md-table>
+            </md-table-card>
+        </md-card>
+
+        <!-- MCP new token dialog -->
+        <md-dialog ref="mcpTokenDialog">
+            <md-dialog-title>MCP Token Created</md-dialog-title>
+            <md-dialog-content>
+                Save this token somewhere safe — it will not be shown again.<br><br>
+                <pre class="token-pre">{{ newMcpToken }}</pre><br>
+                Use it with the InfraBox MCP server:<br>
+                <pre>$ export INFRABOX_MCP_TOKEN=&lt;TOKEN_VALUE&gt;</pre>
+            </md-dialog-content>
+            <md-dialog-actions>
+                <md-button class="md-primary" @click="$refs['mcpTokenDialog'].close()">OK</md-button>
+            </md-dialog-actions>
+        </md-dialog>
+
+        <!-- MCP revoke confirmation dialog -->
+        <md-dialog-confirm
+            ref="mcpRevokeDialog"
+            md-title="Revoke MCP Token"
+            :md-content="`Revoke &quot;${pendingMcpRevoke ? pendingMcpRevoke.name : ''}&quot;? This cannot be undone.`"
+            md-ok-text="Revoke"
+            md-cancel-text="Cancel"
+            @close="onMcpRevokeClose">
+        </md-dialog-confirm>
     </div>
 </template>
 
@@ -208,6 +317,13 @@ export default {
         form: {
             description: '',
             expiresDays: 365
+        },
+        mcpTokens: [],
+        newMcpToken: '',
+        pendingMcpRevoke: null,
+        mcpForm: {
+            name: '',
+            expiresDays: 365
         }
     }),
 
@@ -215,6 +331,10 @@ export default {
         disableAdd () {
             return !this.form.description || this.form.description.length < 3 ||
                 !this.form.expiresDays || this.form.expiresDays < 1 || this.form.expiresDays > 3650
+        },
+        disableMcpAdd () {
+            return !this.mcpForm.name || this.mcpForm.name.length < 3 ||
+                !this.mcpForm.expiresDays || this.mcpForm.expiresDays < 1 || this.mcpForm.expiresDays > 365
         },
         adminProjects () {
             return this.$store.state.projects.filter(p => p.userHasAdminRights())
@@ -227,6 +347,10 @@ export default {
     created () {
         UserTokenService.loadTokens().then((tokens) => {
             this.tokens = tokens
+        }).catch(() => {})
+
+        UserTokenService.loadMcpTokens().then((tokens) => {
+            this.mcpTokens = tokens
         }).catch(() => {})
 
         const adminProjects = this.$store.state.projects.filter(p => p.userHasAdminRights())
@@ -310,6 +434,54 @@ export default {
                 .then((log) => { this.accessLog = log })
                 .catch(() => {})
                 .finally(() => { this.logLoading = false })
+        },
+
+        createMcpToken () {
+            if (this.disableMcpAdd) return
+            UserTokenService.createMcpToken(this.mcpForm.name, {}, this.mcpForm.expiresDays)
+                .then((result) => {
+                    this.mcpTokens.unshift({
+                        token_id: result.token_id,
+                        name: result.name,
+                        enabled_projects: result.enabled_projects,
+                        allow_trigger: result.allow_trigger,
+                        expires_at: result.expires_at,
+                        created_at: new Date().toISOString(),
+                        last_used_at: null
+                    })
+                    this.newMcpToken = result.token
+                    this.$refs['mcpTokenDialog'].open()
+                    this.mcpForm.name = ''
+                    this.mcpForm.expiresDays = 365
+                })
+                .catch(() => {})
+        },
+
+        confirmMcpRevoke (token) {
+            this.pendingMcpRevoke = token
+            this.$refs['mcpRevokeDialog'].open()
+        },
+
+        onMcpRevokeClose (type) {
+            if (type !== 'ok' || !this.pendingMcpRevoke) {
+                this.pendingMcpRevoke = null
+                return
+            }
+            const target = this.pendingMcpRevoke
+            UserTokenService.revokeMcpToken(target.token_id)
+                .then(() => {
+                    this.mcpTokens = this.mcpTokens.filter(t => t.token_id !== target.token_id)
+                    NotificationService.$emit('NOTIFICATION', new Notification({ message: `MCP token "${target.name}" revoked.` }))
+                })
+                .catch(() => {})
+                .finally(() => { this.pendingMcpRevoke = null })
+        },
+
+        toggleMcpTrigger (token) {
+            const newVal = !token.allow_trigger
+            UserTokenService.setMcpTrigger(token.token_id, newVal)
+                .then(() => { token.allow_trigger = newVal })
+                .catch(() => {})
         }
     }
 }
@@ -384,5 +556,19 @@ export default {
 .expiry-expired {
     color: #c62828;
     font-weight: 500;
+}
+
+.mcp-all-projects {
+    color: #888;
+    font-style: italic;
+    font-size: 13px;
+}
+
+.mcp-project-count {
+    font-size: 13px;
+}
+
+.mcp-trigger-switch {
+    margin: 0;
 }
 </style>

--- a/src/dashboard-client/src/components/user/UserGlobalTokens.vue
+++ b/src/dashboard-client/src/components/user/UserGlobalTokens.vue
@@ -297,8 +297,8 @@
                                                 {{ p.name }}
                                             </label>
                                         </div>
-                                        <md-button class="md-raised md-primary md-dense" style="margin-top: 8px" @click="saveScopeEdit(t)">Save</md-button>
-                                        <md-button class="md-dense" style="margin-top: 8px" @click="scopeEditId = null">Cancel</md-button>
+                                        <button class="scope-btn scope-btn-primary" @click="saveScopeEdit(t)">Save</button>
+                                        <button class="scope-btn" @click="scopeEditId = null">Cancel</button>
                                     </div>
                                 </md-table-cell>
                             </md-table-row>
@@ -679,5 +679,33 @@ export default {
 
 .mcp-project-checkbox input {
     cursor: pointer;
+}
+
+.scope-btn {
+    display: inline-block;
+    margin-top: 8px;
+    margin-right: 8px;
+    padding: 6px 16px;
+    border: none;
+    border-radius: 2px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    text-transform: uppercase;
+    background: #e0e0e0;
+    color: #212121;
+}
+
+.scope-btn:hover {
+    background: rgba(0,0,0,0.07);
+}
+
+.scope-btn-primary {
+    background: #009688;
+    color: #fff;
+}
+
+.scope-btn-primary:hover {
+    background: #00796b;
 }
 </style>

--- a/src/dashboard-client/src/components/user/UserGlobalTokens.vue
+++ b/src/dashboard-client/src/components/user/UserGlobalTokens.vue
@@ -222,8 +222,8 @@
                                 <md-tooltip>Create MCP token</md-tooltip>
                             </md-button>
                         </md-list-item>
-                        <md-list-item v-if="userProjects.length > 0" style="flex-wrap: wrap; align-items: flex-start; padding: 0 16px 8px">
-                            <div style="width: 100%; font-size: 13px; color: #666; margin-bottom: 6px;">
+                        <div v-if="userProjects.length > 0" style="padding: 0 16px 12px;">
+                            <div style="font-size: 13px; color: #666; margin-bottom: 6px;">
                                 Project scope
                                 <small style="color: #999; margin-left: 6px;">leave all unchecked to allow access to all projects</small>
                             </div>
@@ -233,7 +233,7 @@
                                     {{ p.name }}
                                 </label>
                             </div>
-                        </md-list-item>
+                        </div>
                     </md-list>
                 </md-card-area>
             </md-card>
@@ -297,8 +297,8 @@
                                                 {{ p.name }}
                                             </label>
                                         </div>
-                                        <md-button class="md-raised md-primary md-dense" @click="saveScopeEdit(t)">Save</md-button>
-                                        <md-button class="md-dense" @click="scopeEditId = null">Cancel</md-button>
+                                        <md-button class="md-raised md-primary md-dense" style="margin-top: 8px" @click="saveScopeEdit(t)">Save</md-button>
+                                        <md-button class="md-dense" style="margin-top: 8px" @click="scopeEditId = null">Cancel</md-button>
                                     </div>
                                 </md-table-cell>
                             </md-table-row>
@@ -603,6 +603,7 @@ export default {
 .log-cell {
     background-color: #f9f9f9 !important;
     padding: 8px 16px !important;
+    overflow: visible !important;
 }
 
 .log-table {

--- a/src/dashboard-client/src/components/user/UserGlobalTokens.vue
+++ b/src/dashboard-client/src/components/user/UserGlobalTokens.vue
@@ -282,7 +282,7 @@
                 <pre>$ export INFRABOX_MCP_TOKEN=&lt;TOKEN_VALUE&gt;</pre>
             </md-dialog-content>
             <md-dialog-actions>
-                <md-button class="md-primary" @click="$refs['mcpTokenDialog'].close()">OK</md-button>
+                <md-button class="md-primary" @click="closeMcpTokenDialog">OK</md-button>
             </md-dialog-actions>
         </md-dialog>
 
@@ -481,7 +481,12 @@ export default {
             const newVal = !token.allow_trigger
             UserTokenService.setMcpTrigger(token.token_id, newVal)
                 .then(() => { token.allow_trigger = newVal })
-                .catch(() => {})
+                .catch(() => { token.allow_trigger = !newVal })
+        },
+
+        closeMcpTokenDialog () {
+            this.$refs['mcpTokenDialog'].close()
+            this.newMcpToken = ''
         }
     }
 }

--- a/src/dashboard-client/src/components/user/UserGlobalTokens.vue
+++ b/src/dashboard-client/src/components/user/UserGlobalTokens.vue
@@ -207,18 +207,32 @@
                 <md-card-area>
                     <md-list class="m-t-md m-b-md">
                         <md-list-item>
-                            <md-input-container class="m-r-sm" style="flex: 2">
+                            <md-input-container class="m-r-sm" style="flex: 2" :class="{'md-input-invalid': mcpNameError}">
                                 <label>Token Name (e.g. "Claude Desktop")</label>
                                 <md-input v-model="mcpForm.name" @keyup.enter.native="createMcpToken"></md-input>
+                                <span class="md-error" v-if="mcpNameError">Name must be at least 3 characters</span>
                             </md-input-container>
-                            <md-input-container class="m-r-sm" style="flex: 0 0 160px">
+                            <md-input-container class="m-r-sm" style="flex: 0 0 160px" :class="{'md-input-invalid': mcpDaysError}">
                                 <label>Validity (days)</label>
                                 <md-input v-model.number="mcpForm.expiresDays" type="number" min="1" max="365" placeholder="365"></md-input>
+                                <span class="md-error" v-if="mcpDaysError">1–365 days</span>
                             </md-input-container>
-                            <md-button :disabled="disableMcpAdd" class="md-icon-button md-list-action" @click="createMcpToken">
+                            <md-button class="md-icon-button md-list-action" @click="createMcpToken">
                                 <md-icon md-theme="running" class="md-primary">add_circle</md-icon>
                                 <md-tooltip>Create MCP token</md-tooltip>
                             </md-button>
+                        </md-list-item>
+                        <md-list-item v-if="userProjects.length > 0" style="flex-wrap: wrap; align-items: flex-start; padding: 0 16px 8px">
+                            <div style="width: 100%; font-size: 13px; color: #666; margin-bottom: 6px;">
+                                Project scope
+                                <small style="color: #999; margin-left: 6px;">leave all unchecked to allow access to all projects</small>
+                            </div>
+                            <div style="display: flex; flex-wrap: wrap; gap: 4px 16px;">
+                                <label v-for="p in userProjects" :key="p.id" class="mcp-project-checkbox">
+                                    <input type="checkbox" :value="p.id" v-model="mcpForm.selectedProjects">
+                                    {{ p.name }}
+                                </label>
+                            </div>
                         </md-list-item>
                     </md-list>
                 </md-card-area>
@@ -239,30 +253,56 @@
                         </md-table-row>
                     </md-table-header>
                     <md-table-body>
-                        <md-table-row v-for="t in mcpTokens" :key="t.token_id">
-                            <md-table-cell>{{ t.name }}</md-table-cell>
-                            <md-table-cell>
-                                <span v-if="!t.enabled_projects || Object.keys(t.enabled_projects).length === 0" class="mcp-all-projects">all projects</span>
-                                <span v-else class="mcp-project-count">{{ Object.keys(t.enabled_projects).length }} project(s)</span>
-                            </md-table-cell>
-                            <md-table-cell>{{ formatDate(t.created_at) }}</md-table-cell>
-                            <md-table-cell>
-                                <span :class="expiryClass(t.expires_at)">
-                                    {{ formatDate(t.expires_at) }}
-                                    <md-icon v-if="isExpiringSoon(t.expires_at)" style="font-size:16px;vertical-align:middle">warning</md-icon>
-                                </span>
-                            </md-table-cell>
-                            <md-table-cell>{{ t.last_used_at ? formatDate(t.last_used_at) : '—' }}</md-table-cell>
-                            <md-table-cell>
-                                <md-switch v-model="t.allow_trigger" @change="toggleMcpTrigger(t)" class="mcp-trigger-switch"></md-switch>
-                            </md-table-cell>
-                            <md-table-cell>
-                                <md-button class="md-icon-button" @click="confirmMcpRevoke(t)">
-                                    <md-icon class="md-primary">delete</md-icon>
-                                    <md-tooltip>Revoke token</md-tooltip>
-                                </md-button>
-                            </md-table-cell>
-                        </md-table-row>
+                        <template v-for="t in mcpTokens">
+                            <md-table-row :key="t.token_id">
+                                <md-table-cell>{{ t.name }}</md-table-cell>
+                                <md-table-cell>
+                                    <span v-if="!t.enabled_projects || Object.keys(t.enabled_projects).length === 0" class="mcp-all-projects">all projects</span>
+                                    <span v-else class="mcp-project-count">{{ Object.keys(t.enabled_projects).length }} project(s)</span>
+                                </md-table-cell>
+                                <md-table-cell>{{ formatDate(t.created_at) }}</md-table-cell>
+                                <md-table-cell>
+                                    <span :class="expiryClass(t.expires_at)">
+                                        {{ formatDate(t.expires_at) }}
+                                        <md-icon v-if="isExpiringSoon(t.expires_at)" style="font-size:16px;vertical-align:middle">warning</md-icon>
+                                    </span>
+                                </md-table-cell>
+                                <md-table-cell>{{ t.last_used_at ? formatDate(t.last_used_at) : '—' }}</md-table-cell>
+                                <md-table-cell>
+                                    <md-switch v-model="t.allow_trigger" @change="toggleMcpTrigger(t)" class="mcp-trigger-switch"></md-switch>
+                                </md-table-cell>
+                                <md-table-cell>
+                                    <md-button class="md-icon-button" @click="toggleScopeEdit(t)">
+                                        <md-icon>edit</md-icon>
+                                        <md-tooltip>Edit project scope</md-tooltip>
+                                    </md-button>
+                                    <md-button class="md-icon-button" @click="confirmMcpRevoke(t)">
+                                        <md-icon class="md-primary">delete</md-icon>
+                                        <md-tooltip>Revoke token</md-tooltip>
+                                    </md-button>
+                                </md-table-cell>
+                            </md-table-row>
+
+                            <!-- Inline scope editor -->
+                            <md-table-row v-if="scopeEditId === t.token_id" :key="t.token_id + '-scope'" class="log-row">
+                                <md-table-cell colspan="7" class="log-cell">
+                                    <div style="padding: 8px 0;">
+                                        <div style="font-size: 13px; color: #666; margin-bottom: 8px;">
+                                            Project scope
+                                            <small style="color: #999; margin-left: 6px;">leave all unchecked to allow access to all projects</small>
+                                        </div>
+                                        <div style="display: flex; flex-wrap: wrap; gap: 4px 16px; margin-bottom: 12px;">
+                                            <label v-for="p in userProjects" :key="p.id" class="mcp-project-checkbox">
+                                                <input type="checkbox" :value="p.id" v-model="scopeEditSelection">
+                                                {{ p.name }}
+                                            </label>
+                                        </div>
+                                        <md-button class="md-raised md-primary md-dense" @click="saveScopeEdit(t)">Save</md-button>
+                                        <md-button class="md-dense" @click="scopeEditId = null">Cancel</md-button>
+                                    </div>
+                                </md-table-cell>
+                            </md-table-row>
+                        </template>
 
                         <md-table-row v-if="mcpTokens.length === 0">
                             <md-table-cell colspan="7">No MCP tokens yet. Create one above.</md-table-cell>
@@ -321,9 +361,12 @@ export default {
         mcpTokens: [],
         newMcpToken: '',
         pendingMcpRevoke: null,
+        scopeEditId: null,
+        scopeEditSelection: [],
         mcpForm: {
             name: '',
-            expiresDays: 365
+            expiresDays: 365,
+            selectedProjects: []
         }
     }),
 
@@ -335,6 +378,16 @@ export default {
         disableMcpAdd () {
             return !this.mcpForm.name || this.mcpForm.name.length < 3 ||
                 !this.mcpForm.expiresDays || this.mcpForm.expiresDays < 1 || this.mcpForm.expiresDays > 365
+        },
+        mcpNameError () {
+            return this.mcpForm.name !== '' && this.mcpForm.name.length < 3
+        },
+        mcpDaysError () {
+            return this.mcpForm.expiresDays !== '' && this.mcpForm.expiresDays !== null &&
+                (this.mcpForm.expiresDays < 1 || this.mcpForm.expiresDays > 365)
+        },
+        userProjects () {
+            return this.$store.state.projects || []
         },
         adminProjects () {
             return this.$store.state.projects.filter(p => p.userHasAdminRights())
@@ -437,8 +490,19 @@ export default {
         },
 
         createMcpToken () {
-            if (this.disableMcpAdd) return
-            UserTokenService.createMcpToken(this.mcpForm.name, {}, this.mcpForm.expiresDays)
+            if (!this.mcpForm.name || this.mcpForm.name.length < 3) {
+                NotificationService.$emit('NOTIFICATION', new Notification({ message: 'Token name must be at least 3 characters.' }))
+                return
+            }
+            const days = this.mcpForm.expiresDays
+            if (!days || days < 1 || days > 365) {
+                NotificationService.$emit('NOTIFICATION', new Notification({ message: 'Validity must be between 1 and 365 days.' }))
+                return
+            }
+            const enabledProjects = this.mcpForm.selectedProjects.length > 0
+                ? this.mcpForm.selectedProjects.reduce((acc, id) => { acc[id] = null; return acc }, {})
+                : {}
+            UserTokenService.createMcpToken(this.mcpForm.name, enabledProjects, this.mcpForm.expiresDays)
                 .then((result) => {
                     this.mcpTokens.unshift({
                         token_id: result.token_id,
@@ -453,6 +517,7 @@ export default {
                     this.$refs['mcpTokenDialog'].open()
                     this.mcpForm.name = ''
                     this.mcpForm.expiresDays = 365
+                    this.mcpForm.selectedProjects = []
                 })
                 .catch(() => {})
         },
@@ -475,6 +540,29 @@ export default {
                 })
                 .catch(() => {})
                 .finally(() => { this.pendingMcpRevoke = null })
+        },
+
+        toggleScopeEdit (token) {
+            if (this.scopeEditId === token.token_id) {
+                this.scopeEditId = null
+                return
+            }
+            this.scopeEditId = token.token_id
+            this.scopeEditSelection = Object.keys(token.enabled_projects || {})
+        },
+
+        saveScopeEdit (token) {
+            const enabledProjects = this.scopeEditSelection.reduce((acc, id) => {
+                acc[id] = null
+                return acc
+            }, {})
+            UserTokenService.updateMcpToken(token.token_id, enabledProjects)
+                .then(() => {
+                    token.enabled_projects = enabledProjects
+                    this.scopeEditId = null
+                    NotificationService.$emit('NOTIFICATION', new Notification({ message: `Scope updated for "${token.name}".` }))
+                })
+                .catch(() => {})
         },
 
         toggleMcpTrigger (token) {
@@ -575,5 +663,19 @@ export default {
 
 .mcp-trigger-switch {
     margin: 0;
+}
+
+.mcp-project-checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 13px;
+    cursor: pointer;
+    user-select: none;
+    color: #444;
+}
+
+.mcp-project-checkbox input {
+    cursor: pointer;
 }
 </style>

--- a/src/dashboard-client/src/components/user/UserGlobalTokens.vue
+++ b/src/dashboard-client/src/components/user/UserGlobalTokens.vue
@@ -566,9 +566,10 @@ export default {
         },
 
         toggleMcpTrigger (token) {
-            const newVal = !token.allow_trigger
+            // v-model has already flipped token.allow_trigger to the new value;
+            // read it directly rather than negating again.
+            const newVal = token.allow_trigger
             UserTokenService.setMcpTrigger(token.token_id, newVal)
-                .then(() => { token.allow_trigger = newVal })
                 .catch(() => { token.allow_trigger = !newVal })
         },
 

--- a/src/dashboard-client/src/services/NewAPIService.js
+++ b/src/dashboard-client/src/services/NewAPIService.js
@@ -67,7 +67,7 @@ class NewAPIService {
         const u = this.api + url
         return Vue.http.patch(u, payload)
             .then((response) => {
-                return response.body
+                return response.body || {}
             })
             .catch(this._handleError(false))
     }

--- a/src/dashboard-client/src/services/NewAPIService.js
+++ b/src/dashboard-client/src/services/NewAPIService.js
@@ -61,6 +61,16 @@ class NewAPIService {
             })
             .catch(this._handleError(false))
     }
+
+    patch (url, payload) {
+        console.log(`PATCH API: ${url}`)
+        const u = this.api + url
+        return Vue.http.patch(u, payload)
+            .then((response) => {
+                return response.body
+            })
+            .catch(this._handleError(false))
+    }
 }
 
 export default new NewAPIService()

--- a/src/dashboard-client/src/services/UserTokenService.js
+++ b/src/dashboard-client/src/services/UserTokenService.js
@@ -59,6 +59,14 @@ class UserTokenService {
         })
     }
 
+    updateMcpToken (tokenId, enabledProjects) {
+        return NewAPIService.patch(`mcp/tokens/${tokenId}`, { enabled_projects: enabledProjects })
+            .catch((err) => {
+                NotificationService.$emit('NOTIFICATION', new Notification(err))
+                throw err
+            })
+    }
+
     revokeMcpToken (tokenId) {
         return NewAPIService.delete(`mcp/tokens/${tokenId}`)
             .catch((err) => {

--- a/src/dashboard-client/src/services/UserTokenService.js
+++ b/src/dashboard-client/src/services/UserTokenService.js
@@ -38,6 +38,43 @@ class UserTokenService {
                 throw err
             })
     }
+    // MCP token methods — /api/v1/mcp/tokens/*
+
+    loadMcpTokens () {
+        return NewAPIService.get('mcp/tokens/')
+            .catch((err) => {
+                NotificationService.$emit('NOTIFICATION', new Notification(err))
+                throw err
+            })
+    }
+
+    createMcpToken (name, enabledProjects, expiresDays) {
+        return NewAPIService.post('mcp/tokens/', {
+            name,
+            enabled_projects: enabledProjects || {},
+            expires_days: expiresDays || 365
+        }).catch((err) => {
+            NotificationService.$emit('NOTIFICATION', new Notification(err))
+            throw err
+        })
+    }
+
+    revokeMcpToken (tokenId) {
+        return NewAPIService.delete(`mcp/tokens/${tokenId}`)
+            .catch((err) => {
+                NotificationService.$emit('NOTIFICATION', new Notification(err))
+                throw err
+            })
+    }
+
+    setMcpTrigger (tokenId, allow) {
+        const method = allow ? 'post' : 'delete'
+        return NewAPIService[method](`mcp/tokens/${tokenId}/trigger`, {})
+            .catch((err) => {
+                NotificationService.$emit('NOTIFICATION', new Notification(err))
+                throw err
+            })
+    }
 }
 
 export default new UserTokenService()


### PR DESCRIPTION
## Summary

- Add MCP token CRUD to `UserTokenService.js` — 4 new methods wiring up the `/api/v1/mcp/tokens/*` endpoints added in #610
- Append a **MCP Tokens** card to the existing `/user/tokens` page (`UserGlobalTokens.vue`) — no new route needed
- Post-create dialog shows the `ib_mcp_*` token value (shown once) with a `INFRABOX_MCP_TOKEN=...` usage hint for the MCP client

## What users can do after this PR

1. Open **My Tokens** in the sidebar
2. Scroll down to the **MCP Tokens** section
3. Create a token with a name and validity period
4. Copy the `ib_mcp_*` value and set `INFRABOX_MCP_TOKEN` in their MCP client config
5. Toggle **trigger** permission per-token via a switch
6. Revoke tokens when no longer needed

## Related

Completes the frontend half of DIARCHERS-1396 / #610 (backend MCP API layer).
