### PR TITLE
feat: support mounting docker config secret for job containers

### DIFF
--- a/deploy/infrabox/templates/function_crd.yaml
+++ b/deploy/infrabox/templates/function_crd.yaml
@@ -34,6 +34,12 @@ spec:
         name: dockerd-config
         subPath: rootca.pem
 {{ end }}
+{{- if .Values.job.docker_config_secret }}
+    -
+        mountPath: /root/.docker/config.json
+        name: docker-config
+        subPath: config.json
+{{ end }}
     -
         name: data-dir
         mountPath: "/data"
@@ -50,6 +56,12 @@ spec:
         name: dockerd-config
         configMap:
             name: infrabox-dockerd-config
+{{- if .Values.job.docker_config_secret }}
+    -
+        name: docker-config
+        secret:
+            secretName: {{ .Values.job.docker_config_secret }}
+{{ end }}
 {{ if .Values.local_cache.enabled }}
     -
         name: local-cache

--- a/deploy/infrabox/values.yaml
+++ b/deploy/infrabox/values.yaml
@@ -360,6 +360,11 @@ job:
         {}
 
     storage_driver: overlay
+    # Name of a K8s Secret (in infrabox-worker namespace) containing a config.json
+    # key with pre-authenticated docker credentials. Allows job containers to pull
+    # from private registries without explicit docker login.
+    # The secret can be managed via ExternalSecret synced from Vault.
+    docker_config_secret: ""
     #rootca_pem: |- # Using base64 encoded string to put the cert in one line
 
 


### PR DESCRIPTION
Allow job pods to pull from private registries (e.g. cgr.dev) without explicit docker login by mounting a pre-authenticated docker config.json from a K8s Secret. The secret can be managed via ExternalSecret synced from Vault, so token rotation only requires updating Vault.