### PR TITLE
fix(DM01-6060): use emptyDir for /root/.docker to fix docker build and login

### DIFF
--- a/deploy/infrabox/templates/function_crd.yaml
+++ b/deploy/infrabox/templates/function_crd.yaml
@@ -36,9 +36,8 @@ spec:
 {{ end }}
 {{- if .Values.job.docker_config_secret }}
     -
-        mountPath: /root/.docker/config.json
+        mountPath: /root/.docker
         name: docker-config
-        subPath: config.json
 {{ end }}
     -
         name: data-dir

--- a/deploy/infrabox/templates/function_crd.yaml
+++ b/deploy/infrabox/templates/function_crd.yaml
@@ -38,10 +38,10 @@ spec:
     -
         mountPath: /tmp/docker-secret
         name: docker-config
-{{ end }}
     -
         name: docker-dir
         mountPath: /root/.docker
+{{ end }}
     -
         name: data-dir
         mountPath: "/data"
@@ -54,19 +54,19 @@ spec:
     -
         name: data-dir
         emptyDir: {}
+{{- if .Values.job.docker_config_secret }}
     -
         name: docker-dir
         emptyDir: {}
-    -
-        name: dockerd-config
-        configMap:
-            name: infrabox-dockerd-config
-{{- if .Values.job.docker_config_secret }}
     -
         name: docker-config
         secret:
             secretName: {{ .Values.job.docker_config_secret }}
 {{ end }}
+    -
+        name: dockerd-config
+        configMap:
+            name: infrabox-dockerd-config
 {{ if .Values.local_cache.enabled }}
     -
         name: local-cache

--- a/deploy/infrabox/templates/function_crd.yaml
+++ b/deploy/infrabox/templates/function_crd.yaml
@@ -36,9 +36,12 @@ spec:
 {{ end }}
 {{- if .Values.job.docker_config_secret }}
     -
-        mountPath: /root/.docker
+        mountPath: /tmp/docker-secret
         name: docker-config
 {{ end }}
+    -
+        name: docker-dir
+        mountPath: /root/.docker
     -
         name: data-dir
         mountPath: "/data"
@@ -50,6 +53,9 @@ spec:
     volumes:
     -
         name: data-dir
+        emptyDir: {}
+    -
+        name: docker-dir
         emptyDir: {}
     -
         name: dockerd-config

--- a/deploy/infrabox/templates/function_crd.yaml
+++ b/deploy/infrabox/templates/function_crd.yaml
@@ -34,6 +34,12 @@ spec:
         name: dockerd-config
         subPath: rootca.pem
 {{ end }}
+{{- if .Values.job.docker_config_secret }}
+    -
+        mountPath: /root/.docker/config.json
+        name: docker-config
+        subPath: config.json
+{{ end }}
     -
         name: data-dir
         mountPath: "/data"
@@ -50,6 +56,12 @@ spec:
         name: dockerd-config
         configMap:
             name: infrabox-dockerd-config
+{{- if .Values.job.docker_config_secret }}
+    -
+        name: docker-config
+        secret:
+            secretName: {{ .Values.job.docker_config_secret }}
+{{ end }}
 {{ if .Values.local_cache.enabled }}
     -
         name: local-cache

--- a/deploy/infrabox/values.yaml
+++ b/deploy/infrabox/values.yaml
@@ -360,6 +360,11 @@ job:
         {}
 
     storage_driver: overlay
+    # Name of a K8s Secret (in infrabox-worker namespace) containing a config.json
+    # key with pre-authenticated docker credentials. Allows job containers to pull
+    # from private registries without explicit docker login.
+    # The secret can be managed via ExternalSecret synced from Vault.
+    docker_config_secret: ""
     #rootca_pem: |- # Using base64 encoded string to put the cert in one line
 
 

--- a/src/job/entrypoint.sh
+++ b/src/job/entrypoint.sh
@@ -4,6 +4,12 @@ mkdir -p /data/infrabox
 mkdir -p /data/tmp
 mkdir -p /data/repo
 mkdir -p ~/.ssh
+mkdir -p /root/.docker
+
+if [ -f /tmp/docker-secret/config.json ]; then
+    cp /tmp/docker-secret/config.json /root/.docker/config.json
+    echo "Docker config copied from secret"
+fi
 
 
 function startDocker() {


### PR DESCRIPTION
## Problem

PR #619 introduced two bugs when `docker_config_secret` is set:

1. `docker login` fails with: `rename /root/.docker/config.json<random> /root/.docker/config.json: device or resource busy`
   - Root cause: `subPath` mounts the secret file as a bind mount on container rootfs (overlayfs), but docker's temp file is also on rootfs — rename crosses device boundaries with the secret tmpfs.

2. `docker build` fails with: `mkdir /root/.docker/buildx: read-only file system`
   - Root cause: mounting the secret directory to `/root/.docker` makes the whole directory read-only.

## Fix

- Mount the docker config secret to `/tmp/docker-secret` (read-only, no conflict)
- Add an `emptyDir` volume mounted at `/root/.docker` (writable)
- In `entrypoint.sh`, copy `/tmp/docker-secret/config.json` → `/root/.docker/config.json` before the docker daemon starts

This ensures:
- cgr.dev credentials are present at container start (no explicit login needed)
- `docker login` can write/rename within the same emptyDir filesystem
- `docker build` can create subdirectories under `/root/.docker/`