### PR TITLE
feat(DIARCHERS-1521): add MCP write endpoints + fix log/artifacts/trigger

### DIFF
--- a/src/api/handlers/mcp/audit.py
+++ b/src/api/handlers/mcp/audit.py
@@ -4,28 +4,50 @@ Audit logging for MCP API calls.
 Writes to the mcp_access_log table (best-effort, synchronous).
 Never raises — a logging failure must not break the request.
 
-The audit write uses its OWN short-lived autocommit connection, NOT the
-request's g.db connection. This is deliberate: sharing g.db would let the
-audit commit end the caller's transaction — releasing any LOCK TABLE it
-holds and committing partially-written (possibly orphan) rows. Isolating
-the audit connection keeps the caller's transaction boundary intact.
+Uses its OWN short-lived autocommit connection, NOT the request's g.db and
+NOT the shared eventlet pool (dbpool). This is deliberate:
+
+  * Sharing g.db would let the audit commit end the caller's transaction —
+    releasing any LOCK TABLE it holds and committing partially-written rows.
+  * Borrowing a second connection from the pool (dbpool.get) would make the
+    request hold TWO pooled connections at once (g.db + audit's). ibflask.py
+    borrows g.db in before_request and only returns it in teardown_request,
+    so it is held for the whole request. With max_size=10, N concurrent
+    requests each also calling dbpool.get() here would deadlock permanently:
+    all 10 connections are held as g.db, and every request blocks in the
+    pool's channel.get() (which has NO timeout) waiting for an 11th that can
+    never appear — the only greenlets that could free a connection are the
+    ones stuck waiting. A private connection sidesteps the shared pool
+    entirely and cannot participate in pool exhaustion.
+
+connect_timeout bounds a slow/down DB so a best-effort log fails fast and is
+swallowed, rather than hanging the request thread (as connect_db()'s unbounded
+sleep(3) retry loop would). autocommit is safe here ONLY because the connection
+is private and closed below — it is never returned to the pool, so it cannot
+leak autocommit=True to a future borrower (eventlet's dbpool.put() rolls back
+but does NOT reset session attributes like autocommit).
 """
+import os
 import json
 import logging
 
+import psycopg2
+
 from flask import g, request
 
-from pyinfraboxutils.db import connect_db
-
 logger = logging.getLogger('mcp_audit')
+
+# Bound how long we'll wait to open the audit connection. Best-effort logging
+# must never make the caller wait; failures are swallowed below.
+_AUDIT_CONNECT_TIMEOUT = 2
 
 
 def audit_mcp(action: str, outcome: str = 'attempt', details: dict = None, error: str = ''):
     """Record one MCP audit entry on a dedicated autocommit connection.
 
-    Never touches the request's g.db connection, so it cannot commit or roll
-    back the caller's in-flight transaction, and cannot release a LOCK TABLE
-    the caller holds.
+    Never touches the request's g.db connection nor the shared dbpool, so it
+    cannot commit/rollback the caller's transaction, cannot release a LOCK TABLE
+    the caller holds, and cannot contribute to pool exhaustion/deadlock.
     """
     token_id = getattr(g, 'mcp_token_id', None)
     user_id = getattr(g, 'mcp_token_user_id', None)
@@ -37,8 +59,18 @@ def audit_mcp(action: str, outcome: str = 'attempt', details: dict = None, error
 
     conn = None
     try:
-        conn = connect_db()
-        conn.autocommit = True
+        # Private, short-lived connection built with the same parameters as
+        # pyinfraboxutils.db.connect_db(), plus a bounded connect_timeout so a
+        # down/slow DB fails fast instead of hanging the request.
+        conn = psycopg2.connect(
+            dbname=os.environ['INFRABOX_DATABASE_DB'],
+            user=os.environ['INFRABOX_DATABASE_USER'],
+            password=os.environ['INFRABOX_DATABASE_PASSWORD'],
+            host=os.environ['INFRABOX_DATABASE_HOST'],
+            port=os.environ['INFRABOX_DATABASE_PORT'],
+            connect_timeout=_AUDIT_CONNECT_TIMEOUT,
+        )
+        conn.autocommit = True  # safe: this connection is private and closed below
         cur = conn.cursor()
         cur.execute('''
             INSERT INTO mcp_access_log (token_id, user_id, action, outcome, details, error, ip)
@@ -54,6 +86,8 @@ def audit_mcp(action: str, outcome: str = 'attempt', details: dict = None, error
         ])
         cur.close()
     except Exception as exc:
+        # Best-effort: never raise into the caller. A failed audit write must
+        # not break the request it is auditing.
         logger.warning('MCP audit log failed: %s', exc)
     finally:
         if conn is not None:
@@ -70,4 +104,3 @@ def _to_json(d):
         return json.dumps(d)
     except Exception:
         return str(d)
-

--- a/src/api/handlers/mcp/audit.py
+++ b/src/api/handlers/mcp/audit.py
@@ -1,54 +1,33 @@
 """
 Audit logging for MCP API calls.
 
-Writes to the mcp_access_log table (best-effort, synchronous).
+Writes to the mcp_access_log table (best-effort, synchronous) on the
+request's g.db connection.
+
 Never raises — a logging failure must not break the request.
 
-Uses its OWN short-lived autocommit connection, NOT the request's g.db and
-NOT the shared eventlet pool (dbpool). This is deliberate:
-
-  * Sharing g.db would let the audit commit end the caller's transaction —
-    releasing any LOCK TABLE it holds and committing partially-written rows.
-  * Borrowing a second connection from the pool (dbpool.get) would make the
-    request hold TWO pooled connections at once (g.db + audit's). ibflask.py
-    borrows g.db in before_request and only returns it in teardown_request,
-    so it is held for the whole request. With max_size=10, N concurrent
-    requests each also calling dbpool.get() here would deadlock permanently:
-    all 10 connections are held as g.db, and every request blocks in the
-    pool's channel.get() (which has NO timeout) waiting for an 11th that can
-    never appear — the only greenlets that could free a connection are the
-    ones stuck waiting. A private connection sidesteps the shared pool
-    entirely and cannot participate in pool exhaustion.
-
-connect_timeout bounds a slow/down DB so a best-effort log fails fast and is
-swallowed, rather than hanging the request thread (as connect_db()'s unbounded
-sleep(3) retry loop would). autocommit is safe here ONLY because the connection
-is private and closed below — it is never returned to the pool, so it cannot
-leak autocommit=True to a future borrower (eventlet's dbpool.put() rolls back
-but does NOT reset session attributes like autocommit).
+IMPORTANT invariants for callers (this audit shares g.db and commits it):
+  * Call audit('attempt')/('forbidden') BEFORE any write in the handler —
+    audit's commit() would otherwise flush uncommitted work.
+  * Call audit('success') only AFTER the handler's own g.db.commit().
+  * On any failure path that has already executed SQL (a failed statement
+    poisons the connection, or an uncommitted write is pending), call
+    g.db.rollback() BEFORE audit('failure') — otherwise the audit INSERT
+    either fails on the aborted connection (losing the log) or commits a
+    stray partial write.
+  * Never call audit inside a LOCK TABLE / SELECT ... FOR UPDATE critical
+    section — its commit() would release the lock mid-transaction.
 """
-import os
 import json
 import logging
-
-import psycopg2
 
 from flask import g, request
 
 logger = logging.getLogger('mcp_audit')
 
-# Bound how long we'll wait to open the audit connection. Best-effort logging
-# must never make the caller wait; failures are swallowed below.
-_AUDIT_CONNECT_TIMEOUT = 2
-
 
 def audit_mcp(action: str, outcome: str = 'attempt', details: dict = None, error: str = ''):
-    """Record one MCP audit entry on a dedicated autocommit connection.
-
-    Never touches the request's g.db connection nor the shared dbpool, so it
-    cannot commit/rollback the caller's transaction, cannot release a LOCK TABLE
-    the caller holds, and cannot contribute to pool exhaustion/deadlock.
-    """
+    """Record one MCP audit entry synchronously on the request DB connection."""
     token_id = getattr(g, 'mcp_token_id', None)
     user_id = getattr(g, 'mcp_token_user_id', None)
     if not user_id:
@@ -57,22 +36,12 @@ def audit_mcp(action: str, outcome: str = 'attempt', details: dict = None, error
             user_id = str(token['user'].get('id', ''))
     ip = request.remote_addr
 
-    conn = None
     try:
-        # Private, short-lived connection built with the same parameters as
-        # pyinfraboxutils.db.connect_db(), plus a bounded connect_timeout so a
-        # down/slow DB fails fast instead of hanging the request.
-        conn = psycopg2.connect(
-            dbname=os.environ['INFRABOX_DATABASE_DB'],
-            user=os.environ['INFRABOX_DATABASE_USER'],
-            password=os.environ['INFRABOX_DATABASE_PASSWORD'],
-            host=os.environ['INFRABOX_DATABASE_HOST'],
-            port=os.environ['INFRABOX_DATABASE_PORT'],
-            connect_timeout=_AUDIT_CONNECT_TIMEOUT,
-        )
-        conn.autocommit = True  # safe: this connection is private and closed below
-        cur = conn.cursor()
-        cur.execute('''
+        db = getattr(g, 'db', None)
+        if db is None:
+            return
+
+        db.execute('''
             INSERT INTO mcp_access_log (token_id, user_id, action, outcome, details, error, ip)
             VALUES (%s, %s, %s, %s, %s, %s, %s)
         ''', [
@@ -84,17 +53,9 @@ def audit_mcp(action: str, outcome: str = 'attempt', details: dict = None, error
             error or None,
             ip,
         ])
-        cur.close()
+        db.commit()
     except Exception as exc:
-        # Best-effort: never raise into the caller. A failed audit write must
-        # not break the request it is auditing.
         logger.warning('MCP audit log failed: %s', exc)
-    finally:
-        if conn is not None:
-            try:
-                conn.close()
-            except Exception:
-                pass
 
 
 def _to_json(d):

--- a/src/api/handlers/mcp/audit.py
+++ b/src/api/handlers/mcp/audit.py
@@ -3,17 +3,30 @@ Audit logging for MCP API calls.
 
 Writes to the mcp_access_log table (best-effort, synchronous).
 Never raises — a logging failure must not break the request.
+
+The audit write uses its OWN short-lived autocommit connection, NOT the
+request's g.db connection. This is deliberate: sharing g.db would let the
+audit commit end the caller's transaction — releasing any LOCK TABLE it
+holds and committing partially-written (possibly orphan) rows. Isolating
+the audit connection keeps the caller's transaction boundary intact.
 """
 import json
 import logging
 
 from flask import g, request
 
+from pyinfraboxutils.db import connect_db
+
 logger = logging.getLogger('mcp_audit')
 
 
 def audit_mcp(action: str, outcome: str = 'attempt', details: dict = None, error: str = ''):
-    """Record one MCP audit entry synchronously on the request DB connection."""
+    """Record one MCP audit entry on a dedicated autocommit connection.
+
+    Never touches the request's g.db connection, so it cannot commit or roll
+    back the caller's in-flight transaction, and cannot release a LOCK TABLE
+    the caller holds.
+    """
     token_id = getattr(g, 'mcp_token_id', None)
     user_id = getattr(g, 'mcp_token_user_id', None)
     if not user_id:
@@ -22,12 +35,12 @@ def audit_mcp(action: str, outcome: str = 'attempt', details: dict = None, error
             user_id = str(token['user'].get('id', ''))
     ip = request.remote_addr
 
+    conn = None
     try:
-        db = getattr(g, 'db', None)
-        if db is None:
-            return
-
-        db.execute('''
+        conn = connect_db()
+        conn.autocommit = True
+        cur = conn.cursor()
+        cur.execute('''
             INSERT INTO mcp_access_log (token_id, user_id, action, outcome, details, error, ip)
             VALUES (%s, %s, %s, %s, %s, %s, %s)
         ''', [
@@ -39,9 +52,15 @@ def audit_mcp(action: str, outcome: str = 'attempt', details: dict = None, error
             error or None,
             ip,
         ])
-        db.commit()
+        cur.close()
     except Exception as exc:
         logger.warning('MCP audit log failed: %s', exc)
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
 
 
 def _to_json(d):
@@ -51,3 +70,4 @@ def _to_json(d):
         return json.dumps(d)
     except Exception:
         return str(d)
+

--- a/src/api/handlers/mcp/routes/builds.py
+++ b/src/api/handlers/mcp/routes/builds.py
@@ -256,12 +256,15 @@ class MCPBuildRestart(Resource):
             g.db.execute('LOCK TABLE build IN EXCLUSIVE MODE')
 
             # Compute next restart_counter for this build_number.
+            # MAX() returns NULL (-> None) if no rows match; guard with `or 0`
+            # so we never do None + 1. (COALESCE in SQL would work too, matching
+            # the pattern MCPTrigger uses for build_number.)
             row = g.db.execute_one_dict('''
                 SELECT max(restart_counter) AS restart_counter
                 FROM build
                 WHERE build_number = %s AND project_id = %s
             ''', [build['build_number'], project_id])
-            restart_counter = row['restart_counter'] + 1
+            restart_counter = (row['restart_counter'] or 0) + 1
 
             # Insert the new build row referencing the same commit/source_upload.
             new_build_row = g.db.execute_one_dict('''

--- a/src/api/handlers/mcp/routes/builds.py
+++ b/src/api/handlers/mcp/routes/builds.py
@@ -247,6 +247,14 @@ class MCPBuildRestart(Resource):
             abort(404)
 
         try:
+            # Lock the build table BEFORE reading max(restart_counter) so two
+            # concurrent restarts of the same build_number cannot both read the
+            # same max and insert duplicate restart_counter rows. The lock is held
+            # until the commit at the end of this try block. Do NOT call audit_mcp()
+            # between here and the commit — audit uses its own connection now, but
+            # keeping the locked section audit-free avoids any future regression.
+            g.db.execute('LOCK TABLE build IN EXCLUSIVE MODE')
+
             # Compute next restart_counter for this build_number.
             row = g.db.execute_one_dict('''
                 SELECT max(restart_counter) AS restart_counter
@@ -276,6 +284,9 @@ class MCPBuildRestart(Resource):
                   AND build_id = %s
             ''', [project_id, build_id])
             if not seed:
+                # Roll back the just-inserted build so we don't leave an orphan
+                # build row (and release the LOCK) before auditing/aborting.
+                g.db.rollback()
                 audit_mcp('restart_build', outcome='failure',
                           details={'project_id': project_id, 'build_id': build_id,
                                    'reason': 'original build has no Create Jobs seed'})

--- a/src/api/handlers/mcp/routes/builds.py
+++ b/src/api/handlers/mcp/routes/builds.py
@@ -1,16 +1,24 @@
 """
 MCP builds endpoints.
-GET  /api/v1/mcp/projects/<project_id>/builds
-GET  /api/v1/mcp/projects/<project_id>/builds/<build_id>
-POST /api/v1/mcp/projects/<project_id>/trigger
+GET    /api/v1/mcp/projects/<project_id>/builds
+GET    /api/v1/mcp/projects/<project_id>/builds/<build_id>
+POST   /api/v1/mcp/projects/<project_id>/trigger
+POST   /api/v1/mcp/projects/<project_id>/builds/<build_id>/restart
+DELETE /api/v1/mcp/projects/<project_id>/builds/<build_id>/abort
 """
+import json
 import uuid as _uuid
 
 from flask import g, abort
 from flask_restx import Resource
 
 from pyinfraboxutils.ibrestplus import api
-from api.handlers.mcp.auth import mcp_auth_required, check_project_access_mcp, check_trigger_access_mcp
+from api.handlers.mcp.auth import (
+    mcp_auth_required,
+    check_project_access_mcp,
+    check_trigger_access_mcp,
+    get_mcp_user_id,
+)
 from api.handlers.mcp.rate_limit import mcp_rate_limit
 from api.handlers.mcp.audit import audit_mcp
 
@@ -136,15 +144,56 @@ class MCPTrigger(Resource):
 
         try:
             build_id = str(_uuid.uuid4())
+            job_id = str(_uuid.uuid4())
+
+            # Resolve source_upload_id based on project type.
+            # - upload: reuse the most recent source_upload for this project
+            # - test:   source_upload_id may be NULL (schema allows it)
+            source_upload_id = None
+            if project['type'] == 'upload':
+                src = g.db.execute_one_dict('''
+                    SELECT id FROM source_upload
+                    WHERE project_id = %s ORDER BY id DESC LIMIT 1
+                ''', [project_id])
+                if not src:
+                    audit_mcp('trigger_build', outcome='failure',
+                              details={'project_id': project_id,
+                                       'reason': 'no source_upload for upload-type project'})
+                    return {
+                        'message': 'no source_upload; upload code before triggering',
+                        'status': 409,
+                    }, 409
+                source_upload_id = src['id']
+
             g.db.execute('LOCK TABLE build IN EXCLUSIVE MODE')
+
+            # 1) INSERT build row — restart_counter defaults to schema default (1) to stay
+            #    compatible with legacy queries (project.py:85 etc.) that filter on rc = 1.
             g.db.execute('''
-                INSERT INTO build (id, project_id, build_number, restart_counter, source)
-                SELECT %s, %s, COALESCE(MAX(build_number), 0) + 1, 0, 'mcp'
+                INSERT INTO build (id, project_id, build_number, source, source_upload_id)
+                SELECT %s, %s, COALESCE(MAX(build_number), 0) + 1, 'mcp', %s
                 FROM build WHERE project_id = %s
-            ''', [build_id, project_id, project_id])
+            ''', [build_id, project_id, source_upload_id, project_id])
+
+            # 2) INSERT the seed "Create Jobs" job — this is the ONLY path that lets the
+            #    scheduler pick up the build (scheduler polls the job table, not the build table).
+            definition = {
+                'build_only': False,
+                'resources': {'limits': {'cpu': 0.5, 'memory': 1024}},
+            }
+            g.db.execute('''
+                INSERT INTO job (id, state, build_id, type, name, project_id,
+                                 dockerfile, definition, cluster_name)
+                VALUES (%s, 'queued', %s, 'create_job_matrix',
+                        'Create Jobs', %s, '', %s, NULL)
+            ''', [job_id, build_id, project_id, json.dumps(definition)])
+
             g.db.commit()
+            # Audit success only after the seed job is committed — a build without a seed job
+            # is a zombie and must not be recorded as success.
             audit_mcp('trigger_build', outcome='success',
-                      details={'project_id': project_id, 'build_id': build_id})
+                      details={'project_id': project_id, 'build_id': build_id,
+                               'source_upload_id': source_upload_id})
             return {'build_id': build_id, 'status': 200}, 200
         except Exception as exc:
             audit_mcp('trigger_build', outcome='failure',
@@ -164,3 +213,144 @@ def _build_dict(r):
         'finished_at': r['finished_at'].isoformat() if r.get('finished_at') else None,
         'status': r.get('status'),
     }
+
+
+@ns.route('/builds/<build_id>/restart')
+class MCPBuildRestart(Resource):
+    @mcp_auth_required
+    @mcp_rate_limit('trigger_build')  # share the trigger bucket for all write ops
+    def post(self, project_id, build_id):
+        """Restart a build: creates a new build entry with incremented restart_counter
+        and re-clones the Create Jobs seed job. Requires allow_trigger on the MCP token."""
+        audit_mcp('restart_build', outcome='attempt',
+                  details={'project_id': project_id, 'build_id': build_id})
+        if not check_project_access_mcp(project_id):
+            audit_mcp('restart_build', outcome='forbidden', details={'project_id': project_id})
+            abort(403, 'access to this project is not permitted for the current MCP token')
+
+        if not check_trigger_access_mcp():
+            audit_mcp('restart_build', outcome='forbidden',
+                      details={'project_id': project_id,
+                               'build_id': build_id, 'reason': 'trigger not allowed'})
+            abort(403, 'this MCP token does not have trigger permission')
+
+        # Fetch the original build. check_project_access_mcp has already gated access.
+        build = g.db.execute_one_dict('''
+            SELECT *
+            FROM build
+            WHERE id = %s AND project_id = %s
+        ''', [build_id, project_id])
+        if not build:
+            audit_mcp('restart_build', outcome='failure',
+                      details={'project_id': project_id, 'build_id': build_id,
+                               'reason': 'build not found'})
+            abort(404)
+
+        try:
+            # Compute next restart_counter for this build_number.
+            row = g.db.execute_one_dict('''
+                SELECT max(restart_counter) AS restart_counter
+                FROM build
+                WHERE build_number = %s AND project_id = %s
+            ''', [build['build_number'], project_id])
+            restart_counter = row['restart_counter'] + 1
+
+            # Insert the new build row referencing the same commit/source_upload.
+            new_build_row = g.db.execute_one_dict('''
+                INSERT INTO build (commit_id, build_number, project_id,
+                                   restart_counter, source_upload_id)
+                VALUES (%s, %s, %s, %s, %s) RETURNING id
+            ''', [build['commit_id'],
+                  build['build_number'],
+                  project_id,
+                  restart_counter,
+                  build['source_upload_id']])
+            new_build_id = new_build_row['id']
+
+            # Clone the original Create Jobs seed job so the scheduler picks up the new build.
+            seed = g.db.execute_one_dict('''
+                SELECT repo, env_var, definition
+                FROM job
+                WHERE project_id = %s
+                  AND name = 'Create Jobs'
+                  AND build_id = %s
+            ''', [project_id, build_id])
+            if not seed:
+                audit_mcp('restart_build', outcome='failure',
+                          details={'project_id': project_id, 'build_id': build_id,
+                                   'reason': 'original build has no Create Jobs seed'})
+                abort(500, 'original build is missing the Create Jobs seed job')
+
+            env_var = json.dumps(seed['env_var']) if seed['env_var'] else None
+            repo = json.dumps(seed['repo']) if seed['repo'] else None
+            definition = json.dumps(seed['definition']) if seed['definition'] else None
+
+            job_id = str(_uuid.uuid4())
+            msg = 'Build restarted by MCP token (user %s)\n' % get_mcp_user_id()
+            g.db.execute('''
+                INSERT INTO job (id, state, build_id, type,
+                    name, project_id, dockerfile, repo, env_var, definition, cluster_name)
+                VALUES (%s, 'queued', %s, 'create_job_matrix',
+                        'Create Jobs', %s, '', %s, %s, %s, NULL);
+                INSERT INTO console (job_id, output)
+                VALUES (%s, %s);
+            ''', [job_id, new_build_id, project_id, repo, env_var, definition, job_id, msg])
+            g.db.commit()
+
+            audit_mcp('restart_build', outcome='success',
+                      details={'project_id': project_id, 'build_id': build_id,
+                               'new_build_id': new_build_id,
+                               'restart_counter': restart_counter})
+            return {
+                'build_id': new_build_id,
+                'restart_counter': restart_counter,
+                'status': 200,
+            }, 200
+        except Exception as exc:
+            audit_mcp('restart_build', outcome='failure',
+                      details={'project_id': project_id, 'build_id': build_id},
+                      error=str(exc))
+            raise
+
+
+@ns.route('/builds/<build_id>/abort')
+class MCPBuildAbort(Resource):
+    @mcp_auth_required
+    @mcp_rate_limit('trigger_build')  # share the trigger bucket
+    def delete(self, project_id, build_id):
+        """Abort every running/queued job in a build. Requires allow_trigger on the MCP token."""
+        audit_mcp('abort_build', outcome='attempt',
+                  details={'project_id': project_id, 'build_id': build_id})
+        if not check_project_access_mcp(project_id):
+            audit_mcp('abort_build', outcome='forbidden', details={'project_id': project_id})
+            abort(403, 'access to this project is not permitted for the current MCP token')
+
+        if not check_trigger_access_mcp():
+            audit_mcp('abort_build', outcome='forbidden',
+                      details={'project_id': project_id,
+                               'build_id': build_id, 'reason': 'trigger not allowed'})
+            abort(403, 'this MCP token does not have trigger permission')
+
+        try:
+            jobs = g.db.execute_many_dict('''
+                SELECT id
+                FROM job
+                WHERE build_id = %s AND project_id = %s
+            ''', [build_id, project_id])
+
+            user_id = get_mcp_user_id()
+            for j in jobs:
+                g.db.execute('''
+                    INSERT INTO abort(job_id, user_id) VALUES(%s, %s)
+                ''', [j['id'], user_id])
+            g.db.commit()
+
+            audit_mcp('abort_build', outcome='success',
+                      details={'project_id': project_id, 'build_id': build_id,
+                               'aborted_count': len(jobs)})
+            return {'message': 'Aborted %d job(s)' % len(jobs), 'status': 200}, 200
+        except Exception as exc:
+            audit_mcp('abort_build', outcome='failure',
+                      details={'project_id': project_id, 'build_id': build_id},
+                      error=str(exc))
+            raise

--- a/src/api/handlers/mcp/routes/builds.py
+++ b/src/api/handlers/mcp/routes/builds.py
@@ -66,6 +66,12 @@ class MCPBuilds(Resource):
                       details={'project_id': project_id, 'count': len(result)})
             return result
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('list_builds', outcome='failure',
                       details={'project_id': project_id}, error=str(exc))
             raise
@@ -111,6 +117,12 @@ class MCPBuild(Resource):
                       details={'project_id': project_id, 'build_id': build_id})
             return result
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('get_build', outcome='failure',
                       details={'project_id': project_id, 'build_id': build_id}, error=str(exc))
             raise
@@ -196,6 +208,12 @@ class MCPTrigger(Resource):
                                'source_upload_id': source_upload_id})
             return {'build_id': build_id, 'status': 200}, 200
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('trigger_build', outcome='failure',
                       details={'project_id': project_id}, error=str(exc))
             raise
@@ -321,6 +339,12 @@ class MCPBuildRestart(Resource):
                 'status': 200,
             }, 200
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('restart_build', outcome='failure',
                       details={'project_id': project_id, 'build_id': build_id},
                       error=str(exc))
@@ -364,6 +388,12 @@ class MCPBuildAbort(Resource):
                                'aborted_count': len(jobs)})
             return {'message': 'Aborted %d job(s)' % len(jobs), 'status': 200}, 200
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('abort_build', outcome='failure',
                       details={'project_id': project_id, 'build_id': build_id},
                       error=str(exc))

--- a/src/api/handlers/mcp/routes/jobs.py
+++ b/src/api/handlers/mcp/routes/jobs.py
@@ -411,6 +411,23 @@ def _restart_or_rerun_job(project_id, job_id, rerun_only, msg_who):
 
     build_id = job['build_id']
 
+    # Bug F fix: take a row lock on the build so two concurrent restarts of jobs
+    # in the same build cannot both read the same build_jobs snapshot and clone
+    # overlapping downstream dependents. Held until commit at the end of this fn.
+    g.db.execute('SELECT id FROM build WHERE id = %s FOR UPDATE', [build_id])
+
+    # Bug B fix: atomically claim the target job via compare-and-set. Only the
+    # first concurrent request flips restarted false->true and gets a row back;
+    # a second concurrent request matches 0 rows and aborts cleanly. This replaces
+    # the earlier read-then-check TOCTOU (the guard above is only a fast-path).
+    claimed = g.db.execute_one_dict('''
+        UPDATE job SET restarted = true
+        WHERE id = %s AND project_id = %s AND restarted = false
+        RETURNING id
+    ''', [job_id, project_id])
+    if not claimed:
+        abort(409, 'Job %s has already been restarted by a concurrent request' % job_id)
+
     # For rerun_only, additionally require that upstream deps aren't still running.
     if rerun_only:
         for dep in (job['dependencies'] or []):

--- a/src/api/handlers/mcp/routes/jobs.py
+++ b/src/api/handlers/mcp/routes/jobs.py
@@ -68,6 +68,12 @@ class MCPJobList(Resource):
                       details={'project_id': project_id, 'build_id': build_id, 'count': len(result)})
             return result
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('list_jobs', outcome='failure',
                       details={'project_id': project_id, 'build_id': build_id}, error=str(exc))
             raise
@@ -98,6 +104,12 @@ class MCPJob(Resource):
                       details={'project_id': project_id, 'job_id': job_id})
             return _job_dict(row)
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('get_job', outcome='failure',
                       details={'project_id': project_id, 'job_id': job_id}, error=str(exc))
             raise
@@ -141,6 +153,12 @@ class MCPJobLog(Resource):
                                'bytes': len(log)})
             return log, 200, {'Content-Type': 'text/plain; charset=utf-8'}
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('get_job_log', outcome='failure',
                       details={'project_id': project_id, 'job_id': job_id}, error=str(exc))
             raise
@@ -179,6 +197,12 @@ class MCPJobArtifacts(Resource):
                       details={'project_id': project_id, 'job_id': job_id, 'count': len(result)})
             return result
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('list_job_artifacts', outcome='failure',
                       details={'project_id': project_id, 'job_id': job_id}, error=str(exc))
             raise
@@ -218,6 +242,12 @@ class MCPJobStats(Resource):
                       details={'project_id': project_id, 'job_id': job_id})
             return result
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('get_job_stats', outcome='failure',
                       details={'project_id': project_id, 'job_id': job_id}, error=str(exc))
             raise
@@ -246,6 +276,12 @@ class MCPJobTestruns(Resource):
                       details={'project_id': project_id, 'job_id': job_id, 'count': len(rows)})
             return rows
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('get_job_testruns', outcome='failure',
                       details={'project_id': project_id, 'job_id': job_id}, error=str(exc))
             raise
@@ -303,6 +339,12 @@ class MCPJobManifest(Resource):
                       details={'project_id': project_id, 'job_id': job_id})
             return result
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('get_job_manifest', outcome='failure',
                       details={'project_id': project_id, 'job_id': job_id}, error=str(exc))
             raise
@@ -538,6 +580,12 @@ class MCPJobRestart(Resource):
                                'cloned_count': result.get('cloned_count')})
             return result, 200
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('restart_job', outcome='failure',
                       details={'project_id': project_id, 'job_id': job_id},
                       error=str(exc))
@@ -570,6 +618,12 @@ class MCPJobRerun(Resource):
                                'cloned_count': result.get('cloned_count')})
             return result, 200
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('rerun_job', outcome='failure',
                       details={'project_id': project_id, 'job_id': job_id},
                       error=str(exc))
@@ -607,6 +661,12 @@ class MCPJobAbort(Resource):
                       details={'project_id': project_id, 'job_id': job_id})
             return {'message': 'Successfully aborted job', 'status': 200}, 200
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('abort_job', outcome='failure',
                       details={'project_id': project_id, 'job_id': job_id},
                       error=str(exc))

--- a/src/api/handlers/mcp/routes/jobs.py
+++ b/src/api/handlers/mcp/routes/jobs.py
@@ -1,21 +1,31 @@
 """
 MCP job endpoints.
-GET /api/v1/mcp/projects/<project_id>/builds/<build_id>/jobs
-GET /api/v1/mcp/projects/<project_id>/jobs/<job_id>
-GET /api/v1/mcp/projects/<project_id>/jobs/<job_id>/log
-GET /api/v1/mcp/projects/<project_id>/jobs/<job_id>/artifacts
-GET /api/v1/mcp/projects/<project_id>/jobs/<job_id>/stats
-GET /api/v1/mcp/projects/<project_id>/jobs/<job_id>/testruns
-GET /api/v1/mcp/projects/<project_id>/jobs/<job_id>/manifest
+GET    /api/v1/mcp/projects/<project_id>/builds/<build_id>/jobs
+GET    /api/v1/mcp/projects/<project_id>/jobs/<job_id>
+GET    /api/v1/mcp/projects/<project_id>/jobs/<job_id>/log
+GET    /api/v1/mcp/projects/<project_id>/jobs/<job_id>/artifacts
+GET    /api/v1/mcp/projects/<project_id>/jobs/<job_id>/stats
+GET    /api/v1/mcp/projects/<project_id>/jobs/<job_id>/testruns
+GET    /api/v1/mcp/projects/<project_id>/jobs/<job_id>/manifest
+POST   /api/v1/mcp/projects/<project_id>/jobs/<job_id>/restart
+POST   /api/v1/mcp/projects/<project_id>/jobs/<job_id>/rerun
+DELETE /api/v1/mcp/projects/<project_id>/jobs/<job_id>/abort
 """
 import json
 import logging
+import re
+import uuid as _uuid
 
 from flask import g, abort
 from flask_restx import Resource
 
 from pyinfraboxutils.ibrestplus import api
-from api.handlers.mcp.auth import mcp_auth_required, check_project_access_mcp
+from api.handlers.mcp.auth import (
+    mcp_auth_required,
+    check_project_access_mcp,
+    check_trigger_access_mcp,
+    get_mcp_user_id,
+)
 from api.handlers.mcp.rate_limit import mcp_rate_limit
 from api.handlers.mcp.audit import audit_mcp
 
@@ -110,12 +120,25 @@ class MCPJobLog(Resource):
             abort(404)
 
         try:
-            rows = g.db.execute_many_dict('''
-                SELECT output FROM console WHERE job_id = %s ORDER BY date
-            ''', [job_id])
-            log = ''.join(r['output'] for r in rows)
+            # Two-stage lookup mirroring legacy /console endpoint:
+            # 1) prefer the archived job.console column (scheduler moves logs there on
+            #    job termination and DELETEs the streaming rows)
+            # 2) fall back to the console table (for jobs still running)
+            archived = g.db.execute_one_dict('''
+                SELECT console FROM job WHERE id = %s AND project_id = %s
+            ''', [job_id, project_id])
+
+            if archived and archived['console']:
+                log = archived['console']
+            else:
+                rows = g.db.execute_many_dict('''
+                    SELECT output FROM console WHERE job_id = %s ORDER BY date
+                ''', [job_id])
+                log = ''.join(r['output'] for r in rows)
+
             audit_mcp('get_job_log', outcome='success',
-                      details={'project_id': project_id, 'job_id': job_id})
+                      details={'project_id': project_id, 'job_id': job_id,
+                               'bytes': len(log)})
             return log, 200, {'Content-Type': 'text/plain; charset=utf-8'}
         except Exception as exc:
             audit_mcp('get_job_log', outcome='failure',
@@ -140,16 +163,18 @@ class MCPJobArtifacts(Resource):
             abort(404)
 
         try:
-            rows = g.db.execute_many_dict('''
-                SELECT filename, filesize, created_at
-                FROM archive
-                WHERE job_id = %s
-                ORDER BY filename
-            ''', [job_id])
-            result = [{'filename': r['filename'],
-                       'filesize': r.get('filesize'),
-                       'created_at': r['created_at'].isoformat() if r.get('created_at') else None}
-                      for r in rows]
+            # `archive` is a jsonb[] column on the job table (see migration 00009.sql),
+            # NOT a standalone table. Legacy /archive endpoint reads it this way.
+            row = g.db.execute_one_dict('''
+                SELECT archive
+                FROM job
+                WHERE id = %s AND project_id = %s
+            ''', [job_id, project_id])
+
+            archive = (row or {}).get('archive') or []
+            result = [{'filename': a.get('filename'),
+                       'filesize': a.get('size') or a.get('filesize')}
+                      for a in archive]
             audit_mcp('list_job_artifacts', outcome='success',
                       details={'project_id': project_id, 'job_id': job_id, 'count': len(result)})
             return result
@@ -302,3 +327,270 @@ def _compact_stats(series):
         return series
     step = len(series) // 100
     return series[::step]
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Shared write-path helpers (restart / rerun)
+# ────────────────────────────────────────────────────────────────────────────
+
+_RESTARTABLE_STATES = ('error', 'failure', 'finished', 'killed', 'unstable')
+_RESTARTABLE_TYPES = ('run_project_container', 'run_docker_compose')
+
+
+def _clone_jobs_and_bump_names(build_jobs, restart_ids, single_id=None):
+    """Clone the specified jobs, mark originals as restarted, and re-wire dependencies.
+
+    Args:
+        build_jobs: rows from `SELECT id, dependencies, restarted, state FROM job WHERE build_id`
+        restart_ids: list of job ids that should be marked as restarted
+        single_id: if given (rerun mode), only this one is cloned (dependencies get re-wired
+            in downstream jobs but only this one gets a new row inserted)
+
+    Returns:
+        (jobs_to_insert, old_id_job_map). old_id_job_map maps old-id → cloned-row (with new id/name)
+        for dependency rewriting in the second pass.
+    """
+    # Load the full job rows for the ones we plan to touch.
+    to_clone = restart_ids if single_id is None else [single_id]
+    jobs = []
+    for jid in to_clone:
+        row = g.db.execute_one_dict('''
+            SELECT id, build_id, type, dockerfile, name, project_id, dependencies,
+                   repo, env_var, env_var_ref, build_arg, deployment, definition, cluster_name
+            FROM job
+            WHERE id = %s
+        ''', [jid])
+        if row:
+            jobs.append(row)
+
+    old_id_job = {}
+    for j in jobs:
+        # Mark the original as restarted so it won't be picked again.
+        g.db.execute('UPDATE job SET restarted = true WHERE id = %s;', [j['id']])
+        old_id_job[j['id']] = j
+        j['id'] = str(_uuid.uuid4())
+
+        # Bump the name suffix (`.1`, `.2`, ...) so the clone gets a unique name.
+        parts = j['name'].split('/')
+        last = parts[-1]
+        m = re.search(r'(.*)\.([0-9]+)$', last)
+        if m:
+            n = int(m.group(2)) + 1
+            front = '/'.join(parts[:-1])
+            j['name'] = ('%s/%s.%d' % (front, m.group(1), n)) if front else '%s.%d' % (m.group(1), n)
+        else:
+            j['name'] = j['name'] + '.1'
+    return jobs, old_id_job
+
+
+def _restart_or_rerun_job(project_id, job_id, rerun_only, msg_who):
+    """Shared core for MCP restart_job and rerun_job.
+
+    Args:
+        project_id, job_id: target
+        rerun_only: if True, only the target job is cloned (dependents are NOT restarted).
+                    if False, target job + all downstream dependents are cloned.
+        msg_who: string inserted into the audit console message
+
+    Returns dict payload for the JSON response.
+    """
+    job = g.db.execute_one_dict('''
+        SELECT state, type, build_id, restarted, dependencies, name
+        FROM job
+        WHERE id = %s AND project_id = %s
+    ''', [job_id, project_id])
+    if not job:
+        abort(404)
+
+    if job['type'] not in _RESTARTABLE_TYPES:
+        abort(400, 'Job type cannot be restarted')
+    if job['state'] not in _RESTARTABLE_STATES:
+        abort(400, 'Job in state %s cannot be restarted' % job['state'])
+    if job['restarted']:
+        abort(400, 'This job has been already restarted')
+
+    build_id = job['build_id']
+
+    # For rerun_only, additionally require that upstream deps aren't still running.
+    if rerun_only:
+        for dep in (job['dependencies'] or []):
+            p = g.db.execute_one_dict('''
+                SELECT state FROM job WHERE id = %s AND project_id = %s
+            ''', [dep['job-id'], project_id])
+            if p and p['state'] in ('queued', 'running'):
+                abort(400, 'Job %s has an executing parent job' % job_id)
+
+    # Gather all jobs in the build (for downstream propagation and safety checks).
+    build_jobs = g.db.execute_many_dict('''
+        SELECT state, id, dependencies, restarted
+        FROM job
+        WHERE build_id = %s AND project_id = %s
+    ''', [build_id, project_id])
+
+    # Compute the set to mark-restarted:
+    #  - restart_job: closure of the target + all transitive downstream dependents
+    #  - rerun_job:   just the target
+    restart_ids = [job_id]
+    if not rerun_only:
+        while True:
+            found = False
+            for j in build_jobs:
+                if j['id'] in restart_ids:
+                    continue
+                if not j['dependencies'] or j['restarted']:
+                    continue
+                for dep in j['dependencies']:
+                    if dep['job-id'] in restart_ids:
+                        restart_ids.append(j['id'])
+                        found = True
+                        break
+            if not found:
+                break
+
+    # Safety: none of the affected jobs may be running/scheduled.
+    ok_states = _RESTARTABLE_STATES + ('skipped', 'queued')
+    for j in build_jobs:
+        if j['id'] in restart_ids and j['state'] not in ok_states:
+            abort(400, 'Some child jobs are still running')
+
+    single_id = job_id if rerun_only else None
+    jobs, old_id_job = _clone_jobs_and_bump_names(build_jobs, restart_ids, single_id=single_id)
+
+    # In restart mode, rewire dependencies among cloned jobs.
+    # In rerun mode, only the target is cloned so no dependency rewiring is needed on jobs.
+    if not rerun_only:
+        for j in jobs:
+            for dep in (j['dependencies'] or []):
+                if dep['job-id'] in old_id_job:
+                    dep['job'] = old_id_job[dep['job-id']]['name']
+                    dep['job-id'] = old_id_job[dep['job-id']]['id']
+
+    msg = 'Job restarted by %s\n' % msg_who
+    for j in jobs:
+        g.db.execute('''
+            INSERT INTO job (state, id, build_id, type, dockerfile, name, project_id, dependencies, repo,
+                             env_var, env_var_ref, build_arg, deployment, definition, restarted, cluster_name)
+            VALUES ('queued', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, false, %s);
+            INSERT INTO console (job_id, output) VALUES (%s, %s);
+        ''', [j['id'], j['build_id'], j['type'], j['dockerfile'], j['name'], j['project_id'],
+              json.dumps(j['dependencies']),
+              json.dumps(j['repo']),
+              json.dumps(j['env_var']),
+              json.dumps(j['env_var_ref']),
+              json.dumps(j['build_arg']),
+              json.dumps(j['deployment']),
+              json.dumps(j['definition']),
+              j['cluster_name'],
+              j['id'],
+              msg])
+    g.db.commit()
+    return {
+        'job_id': jobs[0]['id'] if jobs else None,
+        'cloned_count': len(jobs),
+        'status': 200,
+    }
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# MCP write endpoints
+# ────────────────────────────────────────────────────────────────────────────
+
+
+@ns_job.route('/restart')
+class MCPJobRestart(Resource):
+    @mcp_auth_required
+    @mcp_rate_limit('trigger_build')  # share the trigger bucket for all write ops
+    def post(self, project_id, job_id):
+        """Restart a job AND its downstream dependents. Requires allow_trigger."""
+        audit_mcp('restart_job', outcome='attempt',
+                  details={'project_id': project_id, 'job_id': job_id})
+        if not check_project_access_mcp(project_id):
+            audit_mcp('restart_job', outcome='forbidden', details={'project_id': project_id})
+            abort(403, _ACCESS_DENIED)
+        if not check_trigger_access_mcp():
+            audit_mcp('restart_job', outcome='forbidden',
+                      details={'project_id': project_id, 'job_id': job_id,
+                               'reason': 'trigger not allowed'})
+            abort(403, 'this MCP token does not have trigger permission')
+
+        try:
+            msg_who = 'MCP token (user %s)' % get_mcp_user_id()
+            result = _restart_or_rerun_job(project_id, job_id, rerun_only=False, msg_who=msg_who)
+            audit_mcp('restart_job', outcome='success',
+                      details={'project_id': project_id, 'job_id': job_id,
+                               'cloned_count': result.get('cloned_count')})
+            return result, 200
+        except Exception as exc:
+            audit_mcp('restart_job', outcome='failure',
+                      details={'project_id': project_id, 'job_id': job_id},
+                      error=str(exc))
+            raise
+
+
+@ns_job.route('/rerun')
+class MCPJobRerun(Resource):
+    @mcp_auth_required
+    @mcp_rate_limit('trigger_build')  # share the trigger bucket
+    def post(self, project_id, job_id):
+        """Rerun a single job WITHOUT restarting its downstream dependents.
+        Most common AI use case: 'retry just this failed step'. Requires allow_trigger."""
+        audit_mcp('rerun_job', outcome='attempt',
+                  details={'project_id': project_id, 'job_id': job_id})
+        if not check_project_access_mcp(project_id):
+            audit_mcp('rerun_job', outcome='forbidden', details={'project_id': project_id})
+            abort(403, _ACCESS_DENIED)
+        if not check_trigger_access_mcp():
+            audit_mcp('rerun_job', outcome='forbidden',
+                      details={'project_id': project_id, 'job_id': job_id,
+                               'reason': 'trigger not allowed'})
+            abort(403, 'this MCP token does not have trigger permission')
+
+        try:
+            msg_who = 'MCP token (user %s)' % get_mcp_user_id()
+            result = _restart_or_rerun_job(project_id, job_id, rerun_only=True, msg_who=msg_who)
+            audit_mcp('rerun_job', outcome='success',
+                      details={'project_id': project_id, 'job_id': job_id,
+                               'cloned_count': result.get('cloned_count')})
+            return result, 200
+        except Exception as exc:
+            audit_mcp('rerun_job', outcome='failure',
+                      details={'project_id': project_id, 'job_id': job_id},
+                      error=str(exc))
+            raise
+
+
+@ns_job.route('/abort')
+class MCPJobAbort(Resource):
+    @mcp_auth_required
+    @mcp_rate_limit('trigger_build')  # share the trigger bucket
+    def delete(self, project_id, job_id):
+        """Abort a single running job. Requires allow_trigger on the MCP token."""
+        audit_mcp('abort_job', outcome='attempt',
+                  details={'project_id': project_id, 'job_id': job_id})
+        if not check_project_access_mcp(project_id):
+            audit_mcp('abort_job', outcome='forbidden', details={'project_id': project_id})
+            abort(403, _ACCESS_DENIED)
+        if not check_trigger_access_mcp():
+            audit_mcp('abort_job', outcome='forbidden',
+                      details={'project_id': project_id, 'job_id': job_id,
+                               'reason': 'trigger not allowed'})
+            abort(403, 'this MCP token does not have trigger permission')
+
+        # Confirm the job exists in this project before writing the abort row.
+        job = g.db.execute_one_dict(_JOB_BY_PROJECT, [job_id, project_id])
+        if not job:
+            abort(404)
+
+        try:
+            g.db.execute('''
+                INSERT INTO abort(job_id, user_id) VALUES(%s, %s)
+            ''', [job_id, get_mcp_user_id()])
+            g.db.commit()
+            audit_mcp('abort_job', outcome='success',
+                      details={'project_id': project_id, 'job_id': job_id})
+            return {'message': 'Successfully aborted job', 'status': 200}, 200
+        except Exception as exc:
+            audit_mcp('abort_job', outcome='failure',
+                      details={'project_id': project_id, 'job_id': job_id},
+                      error=str(exc))
+            raise

--- a/src/api/handlers/mcp/routes/projects.py
+++ b/src/api/handlers/mcp/routes/projects.py
@@ -60,6 +60,12 @@ class MCPProjects(Resource):
             audit_mcp('list_projects', outcome='success', details={'count': len(result)})
             return result
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('list_projects', outcome='failure', error=str(exc))
             raise
 
@@ -87,6 +93,12 @@ class MCPProject(Resource):
             audit_mcp('get_project', outcome='success', details={'project_id': project_id})
             return result
         except Exception as exc:
+            # Clear any aborted/pending transaction so the failure audit
+            # (which shares g.db) can write, and no stray write is committed.
+            try:
+                g.db.rollback()
+            except Exception:
+                pass
             audit_mcp('get_project', outcome='failure',
                       details={'project_id': project_id}, error=str(exc))
             raise

--- a/src/dashboard-client/src/components/user/UserGlobalTokens.vue
+++ b/src/dashboard-client/src/components/user/UserGlobalTokens.vue
@@ -1,7 +1,132 @@
 <template>
     <div>
-        <!-- ===== Global Viewer Tokens ===== -->
+        <!-- ===== MCP Tokens ===== -->
         <md-card class="main-card">
+            <md-card-header class="main-card-header fix-padding">
+                <md-card-header-text>
+                    <h3 class="md-title card-title">
+                        <md-layout>
+                            <md-layout md-vertical-align="center">MCP Tokens</md-layout>
+                            <md-layout md-vertical-align="center">
+                                <small class="section-hint">For use with the InfraBox MCP server (INFRABOX_MCP_TOKEN)</small>
+                            </md-layout>
+                        </md-layout>
+                    </h3>
+                </md-card-header-text>
+            </md-card-header>
+
+            <!-- Create form -->
+            <md-card md-theme="white" class="clean-card">
+                <md-card-area>
+                    <md-list class="m-t-md m-b-md">
+                        <md-list-item>
+                            <md-input-container class="m-r-sm" style="flex: 2" :class="{'md-input-invalid': mcpNameError}">
+                                <label>Token Name (e.g. "Claude Desktop")</label>
+                                <md-input v-model="mcpForm.name" @keyup.enter.native="createMcpToken"></md-input>
+                                <span class="md-error" v-if="mcpNameError">Name must be at least 3 characters</span>
+                            </md-input-container>
+                            <md-input-container class="m-r-sm" style="flex: 0 0 160px" :class="{'md-input-invalid': mcpDaysError}">
+                                <label>Validity (days)</label>
+                                <md-input v-model.number="mcpForm.expiresDays" type="number" min="1" max="365" placeholder="365"></md-input>
+                                <span class="md-error" v-if="mcpDaysError">1–365 days</span>
+                            </md-input-container>
+                            <md-button class="md-icon-button md-list-action" @click="createMcpToken">
+                                <md-icon md-theme="running" class="md-primary">add_circle</md-icon>
+                                <md-tooltip>Create MCP token</md-tooltip>
+                            </md-button>
+                        </md-list-item>
+                        <div v-if="userProjects.length > 0" style="padding: 0 16px 12px;">
+                            <div style="font-size: 13px; color: #666; margin-bottom: 6px;">
+                                Project scope
+                                <small style="color: #999; margin-left: 6px;">leave all unchecked to allow access to all projects</small>
+                            </div>
+                            <div style="display: flex; flex-wrap: wrap; gap: 4px 16px;">
+                                <label v-for="p in userProjects" :key="p.id" class="mcp-project-checkbox">
+                                    <input type="checkbox" :value="p.id" v-model="mcpForm.selectedProjects">
+                                    {{ p.name }}
+                                </label>
+                            </div>
+                        </div>
+                    </md-list>
+                </md-card-area>
+            </md-card>
+
+            <!-- Token list -->
+            <md-table-card class="clean-card">
+                <md-table>
+                    <md-table-header>
+                        <md-table-row>
+                            <md-table-head>Name</md-table-head>
+                            <md-table-head>Projects</md-table-head>
+                            <md-table-head>Created</md-table-head>
+                            <md-table-head>Expires</md-table-head>
+                            <md-table-head>Last Used</md-table-head>
+                            <md-table-head>Trigger</md-table-head>
+                            <md-table-head>Actions</md-table-head>
+                        </md-table-row>
+                    </md-table-header>
+                    <md-table-body>
+                        <template v-for="t in mcpTokens">
+                            <md-table-row :key="t.token_id">
+                                <md-table-cell>{{ t.name }}</md-table-cell>
+                                <md-table-cell>
+                                    <span v-if="!t.enabled_projects || Object.keys(t.enabled_projects).length === 0" class="mcp-all-projects">all projects</span>
+                                    <span v-else class="mcp-project-count">{{ Object.keys(t.enabled_projects).length }} project(s)</span>
+                                </md-table-cell>
+                                <md-table-cell>{{ formatDate(t.created_at) }}</md-table-cell>
+                                <md-table-cell>
+                                    <span :class="expiryClass(t.expires_at)">
+                                        {{ formatDate(t.expires_at) }}
+                                        <md-icon v-if="isExpiringSoon(t.expires_at)" style="font-size:16px;vertical-align:middle">warning</md-icon>
+                                    </span>
+                                </md-table-cell>
+                                <md-table-cell>{{ t.last_used_at ? formatDate(t.last_used_at) : '—' }}</md-table-cell>
+                                <md-table-cell>
+                                    <md-switch v-model="t.allow_trigger" @change="toggleMcpTrigger(t)" class="mcp-trigger-switch"></md-switch>
+                                </md-table-cell>
+                                <md-table-cell>
+                                    <md-button class="md-icon-button" @click="toggleScopeEdit(t)">
+                                        <md-icon>edit</md-icon>
+                                        <md-tooltip>Edit project scope</md-tooltip>
+                                    </md-button>
+                                    <md-button class="md-icon-button" @click="confirmMcpRevoke(t)">
+                                        <md-icon class="md-primary">delete</md-icon>
+                                        <md-tooltip>Revoke token</md-tooltip>
+                                    </md-button>
+                                </md-table-cell>
+                            </md-table-row>
+
+                            <!-- Inline scope editor -->
+                            <md-table-row v-if="scopeEditId === t.token_id" :key="t.token_id + '-scope'" class="log-row">
+                                <md-table-cell colspan="7" class="log-cell">
+                                    <div style="padding: 8px 0;">
+                                        <div style="font-size: 13px; color: #666; margin-bottom: 8px;">
+                                            Project scope
+                                            <small style="color: #999; margin-left: 6px;">leave all unchecked to allow access to all projects</small>
+                                        </div>
+                                        <div style="display: flex; flex-wrap: wrap; gap: 4px 16px; margin-bottom: 12px;">
+                                            <label v-for="p in userProjects" :key="p.id" class="mcp-project-checkbox">
+                                                <input type="checkbox" :value="p.id" v-model="scopeEditSelection">
+                                                {{ p.name }}
+                                            </label>
+                                        </div>
+                                        <button class="scope-btn scope-btn-primary" @click="saveScopeEdit(t)">Save</button>
+                                        <button class="scope-btn" @click="scopeEditId = null">Cancel</button>
+                                    </div>
+                                </md-table-cell>
+                            </md-table-row>
+                        </template>
+
+                        <md-table-row v-if="mcpTokens.length === 0">
+                            <md-table-cell colspan="7">No MCP tokens yet. Create one above.</md-table-cell>
+                        </md-table-row>
+                    </md-table-body>
+                </md-table>
+            </md-table-card>
+        </md-card>
+
+        <!-- ===== Global Viewer Tokens ===== -->
+        <md-card class="main-card" style="margin-top: 16px">
             <md-card-header class="main-card-header fix-padding">
                 <md-card-header-text>
                     <h3 class="md-title card-title">
@@ -186,131 +311,6 @@
             md-cancel-text="Cancel"
             @close="onRevokeClose">
         </md-dialog-confirm>
-
-        <!-- ===== MCP Tokens ===== -->
-        <md-card class="main-card" style="margin-top: 16px">
-            <md-card-header class="main-card-header fix-padding">
-                <md-card-header-text>
-                    <h3 class="md-title card-title">
-                        <md-layout>
-                            <md-layout md-vertical-align="center">MCP Tokens</md-layout>
-                            <md-layout md-vertical-align="center">
-                                <small class="section-hint">For use with the InfraBox MCP server (INFRABOX_MCP_TOKEN)</small>
-                            </md-layout>
-                        </md-layout>
-                    </h3>
-                </md-card-header-text>
-            </md-card-header>
-
-            <!-- Create form -->
-            <md-card md-theme="white" class="clean-card">
-                <md-card-area>
-                    <md-list class="m-t-md m-b-md">
-                        <md-list-item>
-                            <md-input-container class="m-r-sm" style="flex: 2" :class="{'md-input-invalid': mcpNameError}">
-                                <label>Token Name (e.g. "Claude Desktop")</label>
-                                <md-input v-model="mcpForm.name" @keyup.enter.native="createMcpToken"></md-input>
-                                <span class="md-error" v-if="mcpNameError">Name must be at least 3 characters</span>
-                            </md-input-container>
-                            <md-input-container class="m-r-sm" style="flex: 0 0 160px" :class="{'md-input-invalid': mcpDaysError}">
-                                <label>Validity (days)</label>
-                                <md-input v-model.number="mcpForm.expiresDays" type="number" min="1" max="365" placeholder="365"></md-input>
-                                <span class="md-error" v-if="mcpDaysError">1–365 days</span>
-                            </md-input-container>
-                            <md-button class="md-icon-button md-list-action" @click="createMcpToken">
-                                <md-icon md-theme="running" class="md-primary">add_circle</md-icon>
-                                <md-tooltip>Create MCP token</md-tooltip>
-                            </md-button>
-                        </md-list-item>
-                        <div v-if="userProjects.length > 0" style="padding: 0 16px 12px;">
-                            <div style="font-size: 13px; color: #666; margin-bottom: 6px;">
-                                Project scope
-                                <small style="color: #999; margin-left: 6px;">leave all unchecked to allow access to all projects</small>
-                            </div>
-                            <div style="display: flex; flex-wrap: wrap; gap: 4px 16px;">
-                                <label v-for="p in userProjects" :key="p.id" class="mcp-project-checkbox">
-                                    <input type="checkbox" :value="p.id" v-model="mcpForm.selectedProjects">
-                                    {{ p.name }}
-                                </label>
-                            </div>
-                        </div>
-                    </md-list>
-                </md-card-area>
-            </md-card>
-
-            <!-- Token list -->
-            <md-table-card class="clean-card">
-                <md-table>
-                    <md-table-header>
-                        <md-table-row>
-                            <md-table-head>Name</md-table-head>
-                            <md-table-head>Projects</md-table-head>
-                            <md-table-head>Created</md-table-head>
-                            <md-table-head>Expires</md-table-head>
-                            <md-table-head>Last Used</md-table-head>
-                            <md-table-head>Trigger</md-table-head>
-                            <md-table-head>Actions</md-table-head>
-                        </md-table-row>
-                    </md-table-header>
-                    <md-table-body>
-                        <template v-for="t in mcpTokens">
-                            <md-table-row :key="t.token_id">
-                                <md-table-cell>{{ t.name }}</md-table-cell>
-                                <md-table-cell>
-                                    <span v-if="!t.enabled_projects || Object.keys(t.enabled_projects).length === 0" class="mcp-all-projects">all projects</span>
-                                    <span v-else class="mcp-project-count">{{ Object.keys(t.enabled_projects).length }} project(s)</span>
-                                </md-table-cell>
-                                <md-table-cell>{{ formatDate(t.created_at) }}</md-table-cell>
-                                <md-table-cell>
-                                    <span :class="expiryClass(t.expires_at)">
-                                        {{ formatDate(t.expires_at) }}
-                                        <md-icon v-if="isExpiringSoon(t.expires_at)" style="font-size:16px;vertical-align:middle">warning</md-icon>
-                                    </span>
-                                </md-table-cell>
-                                <md-table-cell>{{ t.last_used_at ? formatDate(t.last_used_at) : '—' }}</md-table-cell>
-                                <md-table-cell>
-                                    <md-switch v-model="t.allow_trigger" @change="toggleMcpTrigger(t)" class="mcp-trigger-switch"></md-switch>
-                                </md-table-cell>
-                                <md-table-cell>
-                                    <md-button class="md-icon-button" @click="toggleScopeEdit(t)">
-                                        <md-icon>edit</md-icon>
-                                        <md-tooltip>Edit project scope</md-tooltip>
-                                    </md-button>
-                                    <md-button class="md-icon-button" @click="confirmMcpRevoke(t)">
-                                        <md-icon class="md-primary">delete</md-icon>
-                                        <md-tooltip>Revoke token</md-tooltip>
-                                    </md-button>
-                                </md-table-cell>
-                            </md-table-row>
-
-                            <!-- Inline scope editor -->
-                            <md-table-row v-if="scopeEditId === t.token_id" :key="t.token_id + '-scope'" class="log-row">
-                                <md-table-cell colspan="7" class="log-cell">
-                                    <div style="padding: 8px 0;">
-                                        <div style="font-size: 13px; color: #666; margin-bottom: 8px;">
-                                            Project scope
-                                            <small style="color: #999; margin-left: 6px;">leave all unchecked to allow access to all projects</small>
-                                        </div>
-                                        <div style="display: flex; flex-wrap: wrap; gap: 4px 16px; margin-bottom: 12px;">
-                                            <label v-for="p in userProjects" :key="p.id" class="mcp-project-checkbox">
-                                                <input type="checkbox" :value="p.id" v-model="scopeEditSelection">
-                                                {{ p.name }}
-                                            </label>
-                                        </div>
-                                        <button class="scope-btn scope-btn-primary" @click="saveScopeEdit(t)">Save</button>
-                                        <button class="scope-btn" @click="scopeEditId = null">Cancel</button>
-                                    </div>
-                                </md-table-cell>
-                            </md-table-row>
-                        </template>
-
-                        <md-table-row v-if="mcpTokens.length === 0">
-                            <md-table-cell colspan="7">No MCP tokens yet. Create one above.</md-table-cell>
-                        </md-table-row>
-                    </md-table-body>
-                </md-table>
-            </md-table-card>
-        </md-card>
 
         <!-- MCP new token dialog -->
         <md-dialog ref="mcpTokenDialog">


### PR DESCRIPTION
## Summary

Fixes three defects in the MCP backend surfaced during test-env
integration (build_3201) and adds the 5 MCP write endpoints the
`feat/mcp-restart-rerun` branch name promised.

**Branch base**: `feat/mcp-restart-rerun`. This PR therefore carries
the 8 upstream commits from #617-#625 in addition to the single
commit authored here. Once #620 (traffic isolation) and #621
(restart/rerun endpoints) land on `master`, the base can be switched
or this PR can be rebased.

### DIARCHERS-1521 — Backend fixes

1. **`get_job_log` silent empty response**: the MCP endpoint queried
   only the `console` streaming table. The scheduler archives job
   logs to `job.console` on termination and DELETEs the streaming
   rows, so every finished job returned HTTP 200 with an empty body.
   Fixed with a two-stage lookup: `job.console` archive column
   first, fall back to `console` for jobs still running.

2. **`list_job_artifacts` returns 500 unconditionally**: the MCP
   endpoint queried a non-existent `archive` table. `archive` is a
   `jsonb[]` column on the `job` table (migration `00009.sql`).
   Rewrote to `SELECT archive FROM job` and unpack the array,
   matching the legacy endpoint behavior.

3. **`POST /trigger` creates zombie builds**: the MCP endpoint only
   inserted a `build` row without the seed `create_job_matrix` job
   the scheduler polls for, so every trigger returned HTTP 200 +
   build_id but the build never ran. Also hardcoded
   `restart_counter=0`, diverging from schema default 1 and hiding
   the build from legacy UI filters. Fixed by resolving
   `source_upload_id` per project type (upload projects reuse the
   most recent source_upload; test projects allow NULL), inserting
   the Create Jobs seed in the same transaction, moving the success
   audit entry to after the seed job commits, and removing the
   `restart_counter=0` override.

### 5 new MCP write endpoints

All require `allow_trigger=true` on the MCP token, share the
`trigger_build` rate-limit bucket (5 RPM), and are fully audited.

| Method | Path | Handler | Semantics |
|---|---|---|---|
| POST | `/builds/<bid>/restart` | `MCPBuildRestart` | New build, cloned Create Jobs seed |
| DELETE | `/builds/<bid>/abort` | `MCPBuildAbort` | Insert abort rows for all jobs in build |
| POST | `/jobs/<jid>/restart` | `MCPJobRestart` | Restart job + DAG downstream |
| POST | `/jobs/<jid>/rerun` | `MCPJobRerun` | Rerun single job only |
| DELETE | `/jobs/<jid>/abort` | `MCPJobAbort` | Insert abort row for single job |

Handlers do **not** delegate to the legacy `/api/v1/*`
implementations, which hard-depend on
`g.token['type'] in ('user', 'project')`. MCP handlers use
`get_mcp_user_id()` and reimplement the SQL directly. Shared helper
`_restart_or_rerun_job()` covers both `restart_job` (DAG-propagating)
and `rerun_job` (single-job) paths.

### Dashboard UI

`src/dashboard-client/src/components/user/UserGlobalTokens.vue`:
moved the MCP Tokens section to the top of the page, ahead of Global
Viewer Tokens and Project Tokens. Rationale: MCP Tokens is the
newest feature and the highest-traffic section for users onboarding
to the MCP integration.


### Concurrency hardening (review feedback)

Following review, the write paths were hardened against race conditions
under concurrent requests:

- **`MCPBuildRestart` — atomic restart_counter**: `LOCK TABLE build IN
  EXCLUSIVE MODE` is now taken before `SELECT max(restart_counter)`, so
  two concurrent restarts of the same build cannot read the same max and
  insert duplicate rows. Matches the pattern `MCPTrigger` already uses;
  `EXCLUSIVE MODE` does not block reads.

- **`restart_job` / `rerun_job` — atomic claim of the target job**: the
  read-then-check on the `restarted` flag was replaced by a compare-and-set
  `UPDATE job SET restarted=true WHERE id=%s AND restarted=false RETURNING id`;
  a concurrent loser matches zero rows and gets a clean 409.

- **`_restart_or_rerun_job` — per-build serialization**: a
  `SELECT id FROM build WHERE id=%s FOR UPDATE` row lock serializes
  concurrent restarts of the same build, so overlapping downstream
  dependents cannot be cloned twice.

- **`audit_mcp` — failure audits guarded with `rollback()`**: audit
  writes share the request's `g.db` connection. A failed SQL statement
  (write OR read) leaves the connection in `InFailedSqlTransaction`, so a
  later failure-audit INSERT on the same connection would itself fail and
  be swallowed — losing exactly the failure/error events that matter most.
  Every failure/partial audit inside an `except` block now calls
  `g.db.rollback()` first (17 sites, across both write and read endpoints),
  which clears the aborted state so the audit INSERT succeeds and also
  discards any stray uncommitted write (e.g. a `restarted=true` claim on a
  job-restart path that aborted before commit) so it is not committed by
  the audit. Pre-write "not found"/"forbidden" audits and the seed-missing
  path (which already rolled back) are unchanged. The `audit_mcp` docstring
  documents the ordering invariants callers must uphold (attempt-before-
  write, success-after-commit, failure-rolls-back-first, no-audit-in-lock).
