### PR TITLE
fix(DM01-6184): filter migrations by file number + skip comment-only files

### DIFF
--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -18,6 +18,27 @@ def get_files(current_schema_version):
 
     return [(os.path.join(migration_path, f), int(f[:5])) for f in files]
 
+def _has_executable_sql(sql):
+    """Return True iff `sql` contains at least one non-comment, non-blank line.
+
+    `str.strip()` only removes leading/trailing whitespace; SQL line comments
+    (`-- ...`) are kept.  Passing a comment-only string to `cur.execute()`
+    raises `psycopg2.ProgrammingError: can't execute an empty query`, which
+    breaks migration runs whenever a placeholder file (e.g. an intentionally
+    empty migration to close a numbering gap) is applied.  This helper skips
+    such files safely.
+
+    NOTE: This is a lightweight heuristic — it does NOT parse SQL and does
+    not understand `/* ... */` block comments.  For a comment-only migration
+    file to be recognised as empty, use `--` line comments.
+    """
+    for line in sql.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith('--'):
+            return True
+    return False
+
+
 def apply_migration(conn, migration):
     filename = migration[0]
     logger.info("Starting to apply migration %s", filename)
@@ -27,8 +48,13 @@ def apply_migration(conn, migration):
             sql = sql_file.read().strip()
 
             cur = conn.cursor()
-            if sql:
+            if _has_executable_sql(sql):
                 cur.execute(sql)
+            else:
+                logger.info(
+                    "Skipping execute for %s (no non-comment SQL statements)",
+                    filename,
+                )
 
             cur.close()
     elif filename.endswith('.py'):

--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -14,7 +14,7 @@ def get_files(current_schema_version):
     files = [f for f in os.listdir(migration_path) if os.path.isfile(os.path.join(migration_path, f)) and f.startswith('0')]
 
     files.sort(key=lambda f: int(f[:5]))
-    files = files[current_schema_version:]
+    files = [f for f in files if int(f[:5]) > current_schema_version]
 
     return [(os.path.join(migration_path, f), int(f[:5])) for f in files]
 


### PR DESCRIPTION
## Summary

Builds on [#636](https://github.com/SAP/InfraBox/pull/636) (`fix(DM01-6184): filter migrations by file number instead of list index`) and adds a second fix that is needed to fully unblock the `infrabox-db` migration Job.

## Two independent bugs, one root symptom

`test-new` databases starting below `schema_version=46` currently see the migration Job crash with:

```
psycopg2.ProgrammingError: can't execute an empty query
```

There are actually **two** bugs at play, so #636 alone is not enough. This PR keeps #636's fix and adds the missing one.

### Bug 1 — `get_files` used list index instead of file number  ✅ fixed by #636

Historically `00046.sql` did not exist (the sequence went `45 → 47`), and `files = files[current_schema_version:]` used list index to slice pending migrations. Any gap in the numbering desynchronised the index from the file number, silently skipping later migrations. #636 replaces the slice with a file-number filter — kept as-is in this PR.

### Bug 2 — `apply_migration` treats comment-only files as executable  ← this PR adds

Even with #636's filter selecting the correct files, once `00046.sql` (an intentionally empty placeholder that only contains `-- ...` lines) is chosen, the runner still fails:

```python
sql = sql_file.read().strip()   # keeps `--` comment lines
if sql:                          # non-empty string of comments → guard passes
    cur.execute(sql)             # psycopg2 rejects: "can't execute an empty query"
```

The result: the migration Job crashes before ever reaching `00047.sql` (which creates `mcp_token`, `mcp_access_log`, and adds `build.source`) or `00048.sql` (`secret_read_token`). Downstream, MCP-related endpoints return `500` because the tables don't exist.

## Fix in this PR

Add a small `_has_executable_sql()` helper that returns `True` only if the file has at least one non-blank line that isn't a `--` comment. `apply_migration` uses it to decide whether to call `cur.execute()`:

```python
if _has_executable_sql(sql):
    cur.execute(sql)
else:
    logger.info("Skipping execute for %s (no non-comment SQL statements)", filename)
```

`schema_version` is still bumped afterwards, so the placeholder still serves its purpose (closing a numbering gap).

## Scope

- Kept: the `get_files` fix from #636 (unchanged).
- Added: `_has_executable_sql` helper + guard swap in `apply_migration`.
- Only `src/db/migrate.py` changes. No migration file, no DB schema, no API/UI impact.

## Behaviour after this PR

| File type | Before | After |
|---|---|---|
| Regular `.sql` with statements | executed | executed (unchanged) |
| `.sql` with only `-- comments` | crashes with "empty query" | logs "Skipping execute", schema_version advances |
| `.py` migration | `import` + `migrate(conn)` | unchanged |

## Test plan

- Reproduce the failure locally: point migrate.py at a DB at `schema_version=45`, run against a migrations folder containing the current `00046.sql` (comment-only) + `00047.sql`. Confirm the pre-fix code crashes and the post-fix code logs `Skipping execute for ...00046.sql` and completes.
- Deploy to a real environment (e.g. `test-new`) that is currently stuck at `schema_version=45`. Expect the `infrabox-db` Job to succeed and MCP endpoints (`GET/POST /api/v1/mcp/tokens`) to return 200 instead of 500.

## Notes

- `_has_executable_sql()` is a lightweight line-based heuristic. It only recognises `-- line` comments; it does not parse SQL and does not understand `/* block */` comments. That's fine for the current use case (the placeholder file uses `--` comments), but if we ever want to be stricter we can swap in a real tokenizer later.
- This PR is complementary to the effort in `SAP/InfraBox#637` (unrelated feature branch) which also had to work around this same crash. Once this PR merges, that workaround (adding `SELECT 1;` inside `00046.sql`) becomes unnecessary and can be reverted.