### PR TITLE
fix: register SAP Root CA via update-ca-certificates for BuildKit

### DIFF
--- a/src/job/entrypoint.sh
+++ b/src/job/entrypoint.sh
@@ -56,11 +56,15 @@ if [ ! -e /var/run/docker.sock ]; then
         done
         echo "SAP Root CA installed for $(ls /etc/docker/certs.d/ | wc -l) registries"
 
-        # BuildKit's cache registry client uses the system CA bundle, not /etc/docker/certs.d/.
-        # Append the SAP Root CA to the Alpine system bundle so BuildKit can trust
-        # InfraBox internal registries when importing --cache-from manifests via HTTPS.
-        cat /etc/ssl/certs/saprootca.pem >> /etc/ssl/certs/ca-certificates.crt
-        echo "SAP Root CA appended to system CA bundle for BuildKit"
+        # DM01-6122: The previous fix (appending to ca-certificates.crt) did not work because
+        # Docker 23's embedded BuildKit reads the system CA bundle that was compiled into the
+        # dockerd binary, not the file on disk at runtime. The correct approach is to drop the
+        # CA into /usr/local/share/ca-certificates/ and run update-ca-certificates, which
+        # rebuilds ca-certificates.crt before dockerd starts and is the mechanism the Alpine
+        # ca-certificates package officially supports for adding custom CAs.
+        cp /etc/ssl/certs/saprootca.pem /usr/local/share/ca-certificates/saprootca.crt
+        update-ca-certificates
+        echo "SAP Root CA registered via update-ca-certificates for BuildKit"
     fi
 
     echo "Waiting for docker daemon to start up"


### PR DESCRIPTION
## Problem

Follow-up to DM01-5956. The previous fix appended `saprootca.pem` directly to `/etc/ssl/certs/ca-certificates.crt`, but x509 errors persisted in production on `gardener-eu-de-1` when BuildKit imported `--cache-from` manifests.

## Root Cause

Docker 23's embedded BuildKit is a Go binary. Go's `crypto/tls` does **not** re-read `ca-certificates.crt` from disk at runtime — it uses the CA pool that the Alpine `ca-certificates` package builds via `update-ca-certificates`. That tool:
1. Reads entries from `/usr/local/share/ca-certificates/`
2. Rebuilds `/etc/ssl/certs/ca-certificates.crt`
3. Creates symlinks in `/etc/ssl/certs/`

A raw `cat >> ca-certificates.crt` bypasses this mechanism, so the new bytes are present in the file but the symlink index that Go's TLS stack relies on is never updated.

## Fix

Replace the raw append with the proper Alpine mechanism:

```bash
cp /etc/ssl/certs/saprootca.pem /usr/local/share/ca-certificates/saprootca.crt
update-ca-certificates
```

This runs **before** `dockerd` starts, so the CA pool is fully rebuilt before BuildKit makes any TLS connections.

## Verification

Tested locally in `docker:23.0-dind`:
- `update-ca-certificates` increases `ca-certificates.crt` size correctly
- Creates `ca-cert-saprootca.pem` symlink in `/etc/ssl/certs/`

Reproduction job at `InfraBox-examples/dm01-6122` confirmed x509 errors with the old approach. Full verification against production requires a new job image build and deployment.

## Change

`src/job/entrypoint.sh` — 5 lines changed