### PR TITLE
feat(DM01-6251): decouple blocking K8s API calls from scheduler main loop

### DIFF
--- a/src/scheduler/kubernetes/scheduler.py
+++ b/src/scheduler/kubernetes/scheduler.py
@@ -5,6 +5,7 @@ import os
 import random
 import json
 import copy
+import threading
 from datetime import datetime
 
 import requests
@@ -547,6 +548,49 @@ class Scheduler(object):
         self.function_controller = FunctionInvocationController(args)
         self.pipeline_controller = PipelineInvocationController(args)
 
+        # K8s state cache — refreshed every 10s by background thread.
+        # Main scheduling loop reads from cache to avoid blocking on K8s API
+        # calls (which can stall for up to 10s under load and cause job queuing
+        # delays of hours when multiplied across many scheduler ticks).
+        self._k8s_lock = threading.Lock()
+        self._k8s_nodes = []      # items from GET /api/v1/nodes
+        self._k8s_pipelines = []  # items from GET ibpipelineinvocations
+        self._start_k8s_refresh_thread()
+
+    def _start_k8s_refresh_thread(self):
+        def refresh_loop():
+            while True:
+                try:
+                    self._refresh_k8s_nodes()
+                except Exception as e:
+                    self.logger.exception(e)
+                try:
+                    self._refresh_k8s_pipelines()
+                except Exception as e:
+                    self.logger.exception(e)
+                time.sleep(10)
+
+        t = threading.Thread(target=refresh_loop, daemon=True)
+        t.start()
+
+    def _refresh_k8s_nodes(self):
+        h = {'Authorization': 'Bearer %s' % self.args.token}
+        r = requests.get(self.args.api_server + '/api/v1/nodes', headers=h, timeout=10)
+        items = r.json().get('items', [])
+        with self._k8s_lock:
+            self._k8s_nodes = items
+
+    def _refresh_k8s_pipelines(self):
+        h = {'Authorization': 'Bearer %s' % self.args.token}
+        r = requests.get(
+            self.args.api_server + '/apis/core.infrabox.net/v1alpha1/namespaces/%s/ibpipelineinvocations' % self.namespace,
+            headers=h,
+            timeout=10
+        )
+        items = r.json().get('items', [])
+        with self._k8s_lock:
+            self._k8s_pipelines = items
+
     def handle_function_invocations(self):
         self.logger.info("handle function invocations")
         self.function_controller.handle()
@@ -1069,16 +1113,13 @@ class Scheduler(object):
     def handle_orphaned_jobs(self):
         self.logger.info("handle orphaned jobs")
 
-        h = {'Authorization': 'Bearer %s' % self.args.token}
-        r = requests.get(self.args.api_server + '/apis/core.infrabox.net/v1alpha1/namespaces/%s/ibpipelineinvocations' % self.namespace,
-                         headers=h,
-                         timeout=10)
-        data = r.json()
+        with self._k8s_lock:
+            items = list(self._k8s_pipelines)
 
-        if 'items' not in data:
+        if not items:
             return
 
-        for j in data['items']:
+        for j in items:
             if 'metadata' not in j:
                 continue
 
@@ -1257,17 +1298,15 @@ class Scheduler(object):
 
         root_url = os.environ['INFRABOX_ROOT_URL']
 
-        h = {'Authorization': 'Bearer %s' % self.args.token}
-        r = requests.get(self.args.api_server + '/api/v1/nodes',
-                         headers=h,
-                         timeout=10)
-        data = r.json()
+        with self._k8s_lock:
+            items = list(self._k8s_nodes)
+
+        if not items:
+            return
 
         memory = 0
         cpu = 0
         nodes = 0
-
-        items = data.get('items', [])
 
         for i in items:
             metadata = i.get('metadata', {})
@@ -1345,7 +1384,7 @@ class Scheduler(object):
             self.handle()
             self.conn.close()
 
-            time.sleep(1)
+            time.sleep(3)
 
 def main():
     # Arguments

--- a/src/scheduler/kubernetes/scheduler.py
+++ b/src/scheduler/kubernetes/scheduler.py
@@ -555,27 +555,49 @@ class Scheduler(object):
         self._k8s_lock = threading.Lock()
         self._k8s_nodes = []      # items from GET /api/v1/nodes
         self._k8s_pipelines = []  # items from GET ibpipelineinvocations
-        self._start_k8s_refresh_thread()
+        self._start_k8s_refresh_threads()
 
-    def _start_k8s_refresh_thread(self):
-        def refresh_loop():
+    def _start_k8s_refresh_threads(self):
+        # Fix: run initial synchronous fetch so caches are populated before
+        # the first scheduler tick (avoids update_cluster_state skipping the
+        # DB write on startup when the cluster row may not exist yet).
+        try:
+            self._refresh_k8s_nodes()
+        except Exception as e:
+            self.logger.exception(e)
+        try:
+            self._refresh_k8s_pipelines()
+        except Exception as e:
+            self.logger.exception(e)
+
+        # Fix: run nodes and pipelines in separate threads so a slow/hung
+        # nodes API call does not delay the pipelines refresh (and vice versa).
+        def nodes_loop():
             while True:
+                time.sleep(10)
                 try:
                     self._refresh_k8s_nodes()
                 except Exception as e:
                     self.logger.exception(e)
+
+        def pipelines_loop():
+            while True:
+                time.sleep(10)
                 try:
                     self._refresh_k8s_pipelines()
                 except Exception as e:
                     self.logger.exception(e)
-                time.sleep(10)
 
-        t = threading.Thread(target=refresh_loop, daemon=True)
-        t.start()
+        for target in (nodes_loop, pipelines_loop):
+            t = threading.Thread(target=target, daemon=True)
+            t.start()
 
     def _refresh_k8s_nodes(self):
         h = {'Authorization': 'Bearer %s' % self.args.token}
         r = requests.get(self.args.api_server + '/api/v1/nodes', headers=h, timeout=10)
+        # Fix: raise on HTTP error so a non-200 response does not overwrite
+        # the previously valid cache with an empty list.
+        r.raise_for_status()
         items = r.json().get('items', [])
         with self._k8s_lock:
             self._k8s_nodes = items
@@ -587,6 +609,9 @@ class Scheduler(object):
             headers=h,
             timeout=10
         )
+        # Fix: raise on HTTP error so a non-200 response does not overwrite
+        # the previously valid cache with an empty list.
+        r.raise_for_status()
         items = r.json().get('items', [])
         with self._k8s_lock:
             self._k8s_pipelines = items


### PR DESCRIPTION
## Summary

- Move `GET /api/v1/nodes` and `GET ibpipelineinvocations` from the main scheduler loop into a daemon background thread that refreshes every 10s
- Main loop reads K8s state from a lock-protected in-memory cache — no more blocking HTTP calls on the critical scheduling path
- Increase main loop `sleep(1)` → `sleep(3)` to reduce DB and K8s API pressure

## Root Cause

Under K8s API load, the two blocking HTTP calls (10s timeout each) caused the nominal 1s scheduler loop to actually run every 10–20s. With a backlog of queued jobs this multiplied into queue-wait times of hours.

**Evidence**: `generator/di-embedded-tests` queue_wait = 10,211s (~2.8h). Normal expected wait: < 5s.

## How the fix works

Before:
```
main loop (every ~20s when K8s is slow):
  HTTP GET /api/v1/nodes          ← blocks up to 10s
  HTTP GET /ibpipelineinvocations ← blocks up to 10s
  schedule()   ← jobs finally get scheduled
  sleep(1)
```

After:
```
background thread (every 10s, independent):
  HTTP GET /api/v1/nodes          → writes to _k8s_nodes cache
  HTTP GET /ibpipelineinvocations → writes to _k8s_pipelines cache

main loop (every 3s, stable):
  read _k8s_nodes cache    ← microseconds
  read _k8s_pipelines cache ← microseconds
  schedule()               ← runs 20x/min instead of ~3x/min
  sleep(3)
```

## Risk

- K8s state is max 10s stale — node capacity and orphan detection delay by at most 10s, acceptable
- abort/timeout response latency increases by at most 3s, acceptable
- Scheduling correctness unchanged — `schedule()`, `handle_aborts()`, `handle_timeouts()` logic untouched
- Background thread exceptions are caught and logged, main loop unaffected

## Test plan

- [ ] Deploy to test instance and verify scheduler starts without error
- [ ] Submit a batch of jobs and confirm queue_wait drops to seconds
- [ ] Verify orphaned job cleanup still works
- [ ] Monitor scheduler logs for background thread exceptions